### PR TITLE
refactor: Remove atBatStatus from the entire pipeline

### DIFF
--- a/apps/frontend/src/router/index.js
+++ b/apps/frontend/src/router/index.js
@@ -43,12 +43,6 @@ const router = createRouter({
       meta: { requiresAuth: true }
     },
     {
-      path: '/game/:id',
-      name: 'game',
-      component: GameView,
-      meta: { requiresAuth: true }
-    },
-    {
       path: '/game/:id/setup',
       name: 'game-setup',
       component: GameSetupView,

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -117,15 +117,15 @@ const amIDefensivePlayer = computed(() => {
 
 // UI State Computeds
 const bothPlayersNoSetAction = computed(() => {
-  if (!gameStore.gameState.currentAtBat) return false;
+  if (!gameStore.gameState || !gameStore.gameState.currentAtBat) return false;
   return !gameStore.gameState.currentAtBat.batterAction || !gameStore.gameState.currentAtBat.pitcherAction;
 });
 const pitcherOnlySetActions = computed(() => {
-  if (!gameStore.gameState.currentAtBat) return false;
+  if (!gameStore.gameState || !gameStore.gameState.currentAtBat) return false;
   return !!gameStore.gameState.currentAtBat.pitcherAction && !gameStore.gameState.currentAtBat.batterAction;
 });
 const bothPlayersSetAction = computed(() => {
-    if (!gameStore.gameState.currentAtBat) return false;
+    if (!gameStore.gameState || !gameStore.gameState.currentAtBat) return false;
     return !!gameStore.gameState.currentAtBat.batterAction && !!gameStore.gameState.currentAtBat.pitcherAction;
 });
 


### PR DESCRIPTION
This refactors the application to remove the `atBatStatus` field from the backend and frontend. The game state is now managed by the state of the `currentAtBat` object.

- Replaces `atBatStatus`-driven computed properties in the frontend with new logic based on the `currentAtBat` object.
- Preserves the steal functionality using the new state management system.
- Fixes a bug that caused the game to crash on load due to a missing null check.
- Fixes a bug that caused the dashboard to crash by removing a duplicate route definition.