### PR TITLE
feat: Eliminate delay when clicking Next Hitter

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -337,8 +337,21 @@ async function resetRolls(gameId) {
   }
 
 
+  function updateGameData(data) {
+    console.log('📥 STORE: Received game data from socket.');
+    if (data.game) game.value = data.game;
+    if (data.gameState) gameState.value = data.gameState.state_data;
+    if (data.gameEvents) gameEvents.value = data.gameEvents;
+    if (data.batter) batter.value = data.batter;
+    if (data.pitcher) pitcher.value = data.pitcher;
+    if (data.lineups) lineups.value = data.lineups;
+    if (data.rosters) rosters.value = data.rosters;
+    if (data.teams) teams.value = data.teams;
+  }
+
   return { game, gameState, gameEvents, batter, pitcher, lineups, rosters, setupState, teams,
     fetchGame, declareHomeTeam,setGameState,initiateSteal,resolveSteal,submitPitch, submitSwing, fetchGameSetup, submitRoll, submitGameSetup,submitTagUp,
     displayOuts, setDisplayOuts,
-    submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls };
+    submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls,
+    updateGameData };
 })

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -559,8 +559,9 @@ onMounted(async () => {
 
   socket.connect();
   socket.emit('join-game-room', gameId);
-  socket.on('game-updated', () => { 
-    gameStore.fetchGame(gameId);
+  socket.on('game-updated', (data) => {
+    console.log('--- 3. GameView: game-updated event received from socket. ---');
+    gameStore.updateGameData(data);
   });
 });
 


### PR DESCRIPTION
This commit fixes a UI lag issue where the batter card would update with a noticeable delay after the offensive player clicked the "Next Hitter" button.

The root cause was that the client was making a second, unnecessary API call to fetch the game state after being notified of an update via a websocket event.

The fix implements the following changes:
1.  **Backend**: The `/api/games/:gameId/next-hitter` endpoint now calculates the complete, updated game state and includes it as a payload in the `game-updated` websocket event. A reusable function `getAndProcessGameData` was created to avoid code duplication.
2.  **Frontend**: The websocket listener in `GameView.vue` was updated to receive the payload. A new action `updateGameData` was added to the Pinia store to directly update the state from the socket payload, eliminating the need for the `fetchGame` API call.

This results in a much more responsive user experience, as the UI now updates almost instantly.