### PR TITLE
Fix: Inning change not reflected in game log

### DIFF
--- a/apps/backend/gameLogic.js
+++ b/apps/backend/gameLogic.js
@@ -144,6 +144,7 @@ function applyOutcome(state, outcome, batter, pitcher, infieldDefense = 0) {
 
   // --- Handle Inning Change ---
   if (newState.outs >= 3 && !newState.gameOver) {
+    newState.inningChanged = true; // Signal to the server
     const wasTop = newState.isTopInning;
     newState.isTopInning = !newState.isTopInning;
     if (newState.isTopInning) newState.inning++;


### PR DESCRIPTION
When the third out of an inning was recorded, the game state was correctly updated, but the game log was not. This resulted in the linescore not advancing and no notification for the new inning.

This was because the server-side logic that generates game events did not account for the inning change when an at-bat resulted in the third out.

This commit fixes the issue by:
- Adding an `inningChanged` flag to the game state when the third out occurs in `gameLogic.js`.
- Updating the `set-action` and `pitch` API endpoints in `server.js` to check for this flag.
- When the flag is present, the server now generates two new game events: one for "Outs: 3" and another for the new half-inning.