### PR TITLE
feat: Set up database migrations and deployment guide

### DIFF
--- a/apps/backend/DATABASE_SETUP.md
+++ b/apps/backend/DATABASE_SETUP.md
@@ -1,0 +1,71 @@
+# Database Setup and Management on Render
+
+This guide provides instructions for setting up and managing your PostgreSQL database on Render.
+
+## One-Time Setup
+
+You only need to perform these steps once for your application.
+
+### 1. Connect Your Database in Render
+
+1.  Go to your Render Dashboard.
+2.  Navigate to your backend service (the one using this code).
+3.  Go to the "Environment" tab.
+4.  Click "Add Environment Group" or "Add Secret File" and connect the environment group that contains the `DATABASE_URL` from your Render PostgreSQL instance. Render automatically creates this for you when you create a database. Make sure your backend service and your database are in the same region for the best performance.
+
+### 2. Initial Database Migration and Data Ingestion
+
+You need to run the initial setup commands from the Render Shell.
+
+1.  Go to your backend service in the Render Dashboard.
+2.  Click on the "Shell" tab to open a terminal session.
+3.  Wait for the shell to connect. Your code is located in the `/usr/src/app` directory.
+4.  Run the following commands one by one:
+
+    ```bash
+    # Navigate to the backend directory
+    cd apps/backend
+
+    # Install dependencies (if not already done by the build command)
+    npm install
+
+    # Run the database migration to create all tables
+    npm run migrate:up
+
+    # Run the script to populate the 'cards_player' table
+    node ingest-data.js
+    ```
+
+After these commands complete successfully, your database will be fully set up and populated with the initial player card data.
+
+## Ongoing Deployments & Future Changes
+
+### Automatic Migrations
+
+To ensure your database schema is always up-to-date with your code, you should add the migration command to your service's **Build Command** in Render.
+
+1.  Go to your backend service's "Settings" tab in the Render Dashboard.
+2.  Find the "Build & Deploy" section.
+3.  Your Build Command is likely `npm install` or similar. You should add the migration command to run *after* dependencies are installed. A good build command would be:
+
+    ```
+    npm install && cd apps/backend && npm run migrate:up
+    ```
+    *Note: Adjust the `cd apps/backend` part if your root directory is configured differently in Render.*
+
+    This command ensures that every time you deploy a new version of your application, any new database migrations will be applied automatically.
+
+### Making Future Schema Changes
+
+When you need to change the database schema in the future (e.g., add a column, create a new table):
+
+1.  **Create a new migration file locally:**
+    ```bash
+    # From your local machine, in the apps/backend directory
+    npm run migrate:create -- --name your-descriptive-migration-name
+    ```
+2.  **Edit the new migration file:** Add your `pgm.addColumn()`, `pgm.createTable()`, etc. calls to the `up` function, and the corresponding `down` calls.
+3.  **Commit and push the new migration file** to your Git repository.
+4.  **Deploy your application on Render.** The updated Build Command will automatically run your new migration, and your database will be updated.
+
+This workflow provides a safe and reliable way to evolve your database schema over time.

--- a/apps/backend/ingest-data.js
+++ b/apps/backend/ingest-data.js
@@ -4,10 +4,21 @@ const fs = require('fs');
 const csv = require('csv-parser');
 const { Pool } = require('pg');
 
-const pool = new Pool({
-  user: process.env.DB_USER, host: process.env.DB_HOST, database: process.env.DB_DATABASE,
-  password: process.env.DB_PASSWORD, port: process.env.DB_PORT, ssl: false
-});
+const dbConfig = process.env.NODE_ENV === 'production'
+  ? { // For Render/production
+      connectionString: process.env.DATABASE_URL,
+      ssl: {
+        rejectUnauthorized: false,
+      },
+    }
+  : { // For local development
+      user: process.env.DB_USER,
+      host: process.env.DB_HOST,
+      database: process.env.DB_DATABASE,
+      password: process.env.DB_PASSWORD,
+      port: process.env.DB_PORT,
+    };
+const pool = new Pool(dbConfig);
 
 function createChartData(row, isPitcher = false) {
     const chart = {};

--- a/apps/backend/migrations/20250921090000_initial-schema.js
+++ b/apps/backend/migrations/20250921090000_initial-schema.js
@@ -1,0 +1,157 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  // 1. USERS TABLE
+  pgm.createTable('users', {
+    user_id: 'id',
+    email: { type: 'varchar(255)', notNull: true, unique: true },
+    hashed_password: { type: 'text', notNull: true },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+  });
+
+  // 2. CARDS_PLAYER TABLE
+  pgm.createTable('cards_player', {
+    card_id: 'id',
+    name: { type: 'varchar(255)' },
+    team: { type: 'varchar(10)' },
+    year: { type: 'integer' },
+    points: { type: 'integer' },
+    on_base: { type: 'integer' },
+    control: { type: 'integer' },
+    ip: { type: 'integer' },
+    speed: { type: 'varchar(5)' },
+    fielding_ratings: { type: 'jsonb' },
+    chart_data: { type: 'jsonb' },
+  });
+
+  // 3. ROSTERS TABLE
+  pgm.createTable('rosters', {
+    roster_id: 'id',
+    user_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"(user_id)',
+      onDelete: 'CASCADE',
+    },
+    roster_name: { type: 'varchar(100)', notNull: true },
+  });
+  pgm.createIndex('rosters', 'user_id');
+
+  // 4. ROSTER_CARDS TABLE
+  pgm.createTable('roster_cards', {
+    roster_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"rosters"(roster_id)',
+      onDelete: 'CASCADE',
+    },
+    card_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"cards_player"(card_id)',
+      onDelete: 'CASCADE',
+    },
+    is_starter: { type: 'boolean', notNull: true, default: true },
+  });
+  pgm.addConstraint('roster_cards', 'roster_cards_pkey', { primaryKey: ['roster_id', 'card_id'] });
+  pgm.createIndex('roster_cards', 'card_id');
+
+  // 5. GAMES TABLE
+  pgm.createTable('games', {
+    game_id: 'id',
+    status: { type: 'varchar(50)', default: 'pending' },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+    completed_at: { type: 'timestamptz' },
+    current_turn_user_id: { type: 'integer', references: '"users"(user_id)' },
+    home_team_user_id: { type: 'integer', references: '"users"(user_id)' },
+    use_dh: { type: 'boolean' },
+    setup_rolls: { type: 'jsonb' },
+  });
+  pgm.createIndex('games', 'current_turn_user_id');
+  pgm.createIndex('games', 'home_team_user_id');
+
+  // 6. GAME_PARTICIPANTS TABLE
+  pgm.createTable('game_participants', {
+    game_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"games"(game_id)',
+      onDelete: 'CASCADE',
+    },
+    user_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"(user_id)',
+      onDelete: 'CASCADE',
+    },
+    roster_id: { type: 'integer', notNull: true, references: '"rosters"(roster_id)' },
+    home_or_away: { type: 'varchar(4)', notNull: true },
+    league_designation: { type: 'varchar(2)', notNull: true },
+    lineup: { type: 'jsonb' },
+  });
+  pgm.addConstraint('game_participants', 'game_participants_pkey', { primaryKey: ['game_id', 'user_id'] });
+  pgm.createIndex('game_participants', 'user_id');
+  pgm.createIndex('game_participants', 'roster_id');
+
+  // 7. GAME_STATES TABLE
+  pgm.createTable('game_states', {
+    game_state_id: 'id',
+    game_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"games"(game_id)',
+      onDelete: 'CASCADE',
+    },
+    turn_number: { type: 'integer', notNull: true },
+    state_data: { type: 'jsonb', notNull: true },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+  });
+  pgm.createIndex('game_states', 'game_id');
+
+  // 8. GAME_EVENTS TABLE
+  pgm.createTable('game_events', {
+    event_id: 'id',
+    game_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"games"(game_id)',
+      onDelete: 'CASCADE',
+    },
+    turn_number: { type: 'integer' },
+    user_id: { type: 'integer', references: '"users"(user_id)' },
+    event_type: { type: 'varchar(100)' },
+    log_message: { type: 'text' },
+    timestamp: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+  });
+  pgm.createIndex('game_events', 'game_id');
+  pgm.createIndex('game_events', 'user_id');
+};
+
+exports.down = pgm => {
+  pgm.dropTable('game_events');
+  pgm.dropTable('game_states');
+  pgm.dropTable('game_participants');
+  pgm.dropTable('games');
+  pgm.dropTable('roster_cards');
+  pgm.dropTable('rosters');
+  pgm.dropTable('cards_player');
+  pgm.dropTable('users');
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,9 @@
   "main": "ingest_data.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "migrate:create": "node-pg-migrate -r dotenv/config create",
+    "migrate:up": "node-pg-migrate -r dotenv/config up"
   },
   "keywords": [],
   "author": "",
@@ -19,5 +21,8 @@
     "jsonwebtoken": "^9.0.2",
     "pg": "^8.16.3",
     "socket.io": "^4.8.1"
+  },
+  "devDependencies": {
+    "node-pg-migrate": "^7.5.2"
   }
 }


### PR DESCRIPTION
This change introduces a robust database migration system using `node-pg-migrate` to manage the database schema.

Key changes:
- Added `node-pg-migrate` and configured scripts in `package.json` for creating and applying migrations.
- Created an initial migration file that defines the entire database schema, including tables, foreign keys, and performance indexes.
- Updated the `ingest-data.js` script to use a production-ready database connection, making it compatible with the Render environment.
- Added a `DATABASE_SETUP.md` file with comprehensive instructions for setting up the database, running migrations, and managing future schema changes on Render.