### PR TITLE
fix: Add user_id to teams table to resolve API error

### DIFF
--- a/apps/backend/migrations/20250921100000_create-teams.js
+++ b/apps/backend/migrations/20250921100000_create-teams.js
@@ -5,6 +5,11 @@ exports.up = pgm => {
     name: { type: 'varchar(100)', notNull: true },
     display_format: { type: 'varchar(50)' },
     logo_url: { type: 'text' },
+    user_id: {
+      type: 'integer',
+      references: '"users"(user_id)',
+      onDelete: 'SET NULL',
+    },
   });
 };
 


### PR DESCRIPTION
The /api/available-teams endpoint was returning a generic "Server error." message. Direct testing with curl confirmed this server-side failure.

The endpoint's code attempts to query the `teams` table for rows where `user_id` is NULL. The investigation concluded that this query was failing because the `user_id` column did not exist in the `teams` table schema, causing the database to throw an error which was caught by the server's error handler.

This commit amends the database migration for the `teams` table to include the necessary `user_id` column. This will allow the API query to execute successfully, resolving the server error and enabling the frontend to receive the list of available teams.