### PR TITLE
In the RegisterView and DashboardView, the team name was being displayed

### DIFF
--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -57,7 +57,7 @@ onUnmounted(() => {
     <header class="team-header" :style="{ backgroundColor: authStore.user.team.primary_color, color: authStore.user.team.secondary_color }">
       <img :src="authStore.user.team.logo_url" :alt="authStore.user.team.name" class="team-logo" />
       <div class="team-info">
-        <h1>{{ authStore.user.team.city }} {{ authStore.user.team.name }}</h1>
+        <h1>{{ authStore.user.team.display_format }}</h1>
         <p>Owner: {{ authStore.user.owner }}</p>
       </div>
     </header>

--- a/apps/frontend/src/views/RegisterView.vue
+++ b/apps/frontend/src/views/RegisterView.vue
@@ -58,7 +58,7 @@ onMounted(() => {
           <select id="team_id" v-model="team_id" required>
             <option :value="null" disabled>-- Available Teams --</option>
             <option v-for="team in authStore.availableTeams" :key="team.team_id" :value="team.team_id">
-              {{ team.city }} {{ team.name }}
+              {{ team.display_format }}
             </option>
           </select>
         </div>


### PR DESCRIPTION
by concatenating the city and name properties.

This change updates both views to use the `display_format` property of the team object, which is consistent with other parts of the site.