### PR TITLE
feat: Update data ingestion to include new team fields and image URLs

### DIFF
--- a/apps/backend/ingest-data.js
+++ b/apps/backend/ingest-data.js
@@ -57,8 +57,8 @@ async function ingestData() {
     // Process and insert teams
     const teams = await processCsv('teams.csv');
     for (const team of teams) {
-      const insertQuery = `INSERT INTO teams (city, name, display_format, logo_url) VALUES ($1, $2, $3, $4)`;
-      const values = [team.city, team.name, team.display_format, team.logo_url];
+      const insertQuery = `INSERT INTO teams (city, name, display_format, logo_url, abbreviation, primary_color, secondary_color) VALUES ($1, $2, $3, $4, $5, $6, $7)`;
+      const values = [team.city, team.name, team.display_format, team.logo_url, team.abbreviation, team.primary_color, team.secondary_color];
       await client.query(insertQuery, values);
     }
 
@@ -112,6 +112,10 @@ async function ingestData() {
       const values = [card.name, card.team, card.set_name, card.card_number, card.year, card.points, card.on_base, card.control, card.ip, card.speed, card.fielding_ratings, card.chart_data];
       await client.query(insertQuery, values);
     }
+
+    // After all data is inserted, run the image updates
+    const imageUpdatesSql = fs.readFileSync('image_updates.sql', 'utf8');
+    await client.query(imageUpdatesSql);
 
     await client.query('COMMIT');
     console.log('✅ Data ingestion complete!');

--- a/apps/backend/migrations/20250922171700_add_new_columns.js
+++ b/apps/backend/migrations/20250922171700_add_new_columns.js
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.addColumns('teams', {
+    abbreviation: { type: 'varchar(10)' },
+    primary_color: { type: 'varchar(7)' },
+    secondary_color: { type: 'varchar(7)' },
+  });
+  pgm.addColumns('cards_player', {
+    image_url: { type: 'text' },
+  });
+};
+
+exports.down = pgm => {
+  pgm.dropColumns('teams', ['abbreviation', 'primary_color', 'secondary_color']);
+  pgm.dropColumns('cards_player', ['image_url']);
+};


### PR DESCRIPTION
This commit updates the data ingestion process to include the `abbreviation`, `primary_color`, and `secondary_color` fields for teams. It also automates the execution of the `image_updates.sql` script to populate the `image_url` for player cards.

A new migration has been added to support these schema changes.