### PR TITLE
Fix: Adjust nav toolbar for mobile view

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -69,4 +69,35 @@ const isGamePage = computed(() => route.name === 'game');
   width: auto;   /* Allow the width to adjust automatically */
   border-radius: 4px; /* A squircle looks better than a forced circle */
 }
+
+/* ADD THIS MEDIA QUERY */
+@media (max-width: 768px) {
+  .global-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+  }
+
+  .nav-left {
+    flex-basis: auto;
+    order: 1;
+  }
+
+  .nav-center {
+    order: 3;
+    width: 100%; /* Ensure it takes full width to be scrollable if needed */
+    overflow-x: auto; /* Allows horizontal scrolling for the linescore */
+    -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
+    scrollbar-width: none; /* For Firefox */
+  }
+
+  .nav-center::-webkit-scrollbar {
+    display: none; /* For Chrome, Safari, and Opera */
+  }
+
+  .nav-right {
+    order: 2;
+  }
+}
 </style>


### PR DESCRIPTION
The navigation toolbar was not responsive and caused layout issues on mobile devices. The line score was getting cut off, and the navigation elements were overlapping.

This change introduces a media query to apply specific styles for screens up to 768px wide. The flexbox layout is adjusted to wrap elements, and the line score container is made horizontally scrollable to fit on smaller screens. This ensures the navigation bar is usable on mobile devices.