### PR TITLE
Fix: Correct mobile and responsive navigation bar styling

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -73,31 +73,28 @@ const isGamePage = computed(() => route.name === 'game');
 /* ADD THIS MEDIA QUERY */
 @media (max-width: 768px) {
   .global-nav {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
+    padding: 0.5rem;
     gap: 1rem;
   }
 
-  .nav-left {
-    flex-basis: auto;
-    order: 1;
+  .nav-left, .nav-right {
+    flex-shrink: 0;
   }
 
   .nav-center {
-    order: 3;
-    width: 100%; /* Ensure it takes full width to be scrollable if needed */
-    overflow-x: auto; /* Allows horizontal scrolling for the linescore */
-    -webkit-overflow-scrolling: touch; /* Smooth scrolling on iOS */
+    flex-grow: 1;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
     scrollbar-width: none; /* For Firefox */
+    min-width: 0;
   }
 
   .nav-center::-webkit-scrollbar {
-    display: none; /* For Chrome, Safari, and Opera */
+      display: none; /* For Chrome, Safari, and Opera */
   }
 
-  .nav-right {
-    order: 2;
+  .nav-left {
+      flex-basis: auto;
   }
 }
 </style>

--- a/jules-scratch/verification/verify_navbar.py
+++ b/jules-scratch/verification/verify_navbar.py
@@ -1,0 +1,51 @@
+from playwright.sync_api import sync_playwright
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Set viewport to a mobile size
+    page.set_viewport_size({"width": 375, "height": 812})
+
+    # Go to registration page
+    page.goto("http://localhost:5174/register")
+    page.wait_for_load_state("networkidle")
+
+    # Wait for the team options to be loaded
+    page.wait_for_selector('select[id="team_id"] option[value="3"]')
+
+    # Register a new user
+    page.get_by_label("Email").fill("test@test.com")
+    page.get_by_label("Password").fill("password")
+    page.get_by_label("Owner First Name").fill("Test")
+    page.get_by_label("Owner Last Name").fill("User")
+    page.get_by_label("Select Your Team").select_option(label="New York Colossus")
+    page.get_by_role("button", name="Create Account & Claim Team").click()
+
+    # Wait for redirection to login page
+    page.wait_for_url("**/login")
+
+    # Login with the new user
+    page.get_by_label("Email").fill("test@test.com")
+    page.get_by_label("Password").fill("password")
+    page.get_by_role("button", name="Login").click()
+    page.wait_for_url("**/dashboard")
+
+    # Go to game page
+    print("Navigating to game page...")
+    page.goto("http://localhost:5174/game/1")
+
+    # Wait for the nav bar to be visible
+    print("Waiting for global nav to be visible...")
+    page.wait_for_selector(".global-nav")
+
+    # Take a screenshot
+    print("Taking screenshot...")
+    page.screenshot(path="jules-scratch/verification/verification.png")
+    print("Screenshot saved to jules-scratch/verification/verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
The global navigation bar was exhibiting strange behavior on mobile devices and when the browser window was resized to a smaller width. The elements would wrap and be incorrectly aligned.

This was caused by a media query that changed the flexbox properties of the navigation bar, causing it to wrap its contents.

This commit fixes the issue by:
- Removing the `flex-wrap: wrap` and `justify-content: center` properties from the media query.
- Ensuring the navigation bar stays as a single row.
- Allowing the center element (the linescore) to scroll horizontally when it overflows.
- Preventing the left and right elements from shrinking.

This results in a consistent and clean look for the navigation bar across all screen sizes, as requested.