### PR TITLE
feat: Update bases and outs display logic

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -375,10 +375,12 @@ const gameEventsToDisplay = computed(() => {
 
 // in GameView.vue
 const basesToDisplay = computed(() => {
-  // If the outcome should be hidden, show the bases from the *previous* completed at-bat.
   if (shouldHidePlayOutcome.value) {
-    // This safely handles the first at-bat of the game where lastCompletedAtBat is null.
-    return gameStore.gameState?.lastCompletedAtBat?.bases || { 1: null, 2: null, 3: null };
+    if (opponentReadyForNext.value) {
+      return gameStore.gameState?.lastCompletedAtBat?.basesBeforePlay || { first: null, second: null, third: null };
+    } else {
+      return gameStore.gameState?.currentAtBat?.basesBeforePlay || { first: null, second: null, third: null };
+    }
   }
 
   // Otherwise, show the current, live bases.
@@ -386,10 +388,12 @@ const basesToDisplay = computed(() => {
 });
 
 const outsToDisplay = computed(() => {
-  // If the outcome should be hidden, show the outs from the *previous* completed at-bat.
   if (shouldHidePlayOutcome.value) {
-    // If there was no previous at-bat, the outs count was 0.
-    return gameStore.gameState?.lastCompletedAtBat?.outs || 0;
+    if (opponentReadyForNext.value) {
+      return gameStore.gameState?.lastCompletedAtBat?.outsBeforePlay || 0;
+    } else {
+      return gameStore.gameState?.currentAtBat?.outsBeforePlay || 0;
+    }
   }
   
   // Otherwise, show the current, live number of outs.


### PR DESCRIPTION
Updates the logic for displaying bases and outs when the play outcome is hidden.

- If the opponent is not ready for the next play, the state before the play from the current at-bat is shown.
- If the opponent is ready for the next play, the state before the play from the last completed at-bat is shown.

This change also corrects a bug where the fallback bases object had an incorrect format.