### PR TITLE
I've added a conditional delay for revealing the outcome of an at-bat…

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -898,6 +898,7 @@ app.post('/api/games/:gameId/set-action', authenticateToken, async (req, res) =>
       }
       const { newState, events } = applyOutcome(finalState, outcome, batter, pitcher);
       finalState = { ...newState };
+      finalState.defensivePlayerCompletedAction = false;
       finalState.currentAtBat.swingRollResult = { roll: swingRoll, outcome, batter, eventCount: events.length };
       
       
@@ -1013,6 +1014,7 @@ app.post('/api/games/:gameId/pitch', authenticateToken, async (req, res) => {
             }
             const { newState, events } = applyOutcome(finalState, outcome, batter, pitcher);
             finalState = { ...newState };
+            finalState.defensivePlayerCompletedAction = true;
             finalState.currentAtBat.swingRollResult = { roll: swingRoll, outcome, batter, eventCount: events.length };
 
             // --- ADD THESE DEBUG LOGS ---
@@ -1119,6 +1121,8 @@ app.post('/api/games/:gameId/next-hitter', authenticateToken, async (req, res) =
         const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
         newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
       }
+
+      newState.defensivePlayerCompletedAction = false; // Reset for the new at-bat cycle
       
       // 3. Create a fresh scorecard for the new at-bat.
       const { batter, pitcher } = await getActivePlayers(gameId, newState);

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -276,17 +276,26 @@ const isSwingResultVisible = ref(false);
 // in GameView.vue
 watch(bothPlayersSetAction, (isRevealing) => {
   if (isRevealing) {
+    // If we've already seen the result (e.g. page refresh), show it immediately.
     if (hasSeenResult.value) {
-      // User has seen it before (e.g., after reload), show immediately.
       isSwingResultVisible.value = true;
-    } else {
-      // First time seeing the result for this at-bat.
-      // Wait 900ms, then show it and mark it as seen.
+      return;
+    }
+
+    const defensivePlayerCompleted = gameStore.gameState?.defensivePlayerCompletedAction;
+
+    // The special case: defensive player is last and it's their turn to see the delay.
+    if (amIDefensivePlayer.value && defensivePlayerCompleted) {
       setTimeout(() => {
         isSwingResultVisible.value = true;
         hasSeenResult.value = true;
         localStorage.setItem(seenResultStorageKey, 'true');
       }, 900);
+    } else {
+      // In all other cases, show the result immediately.
+      isSwingResultVisible.value = true;
+      hasSeenResult.value = true;
+      localStorage.setItem(seenResultStorageKey, 'true');
     }
   } else {
     if (!initialLoadComplete.value) return;


### PR DESCRIPTION
…. This delay is now only applied to the defensive player and only when they are the second player to submit their action.

To achieve this, I've added a `defensivePlayerCompletedAction` flag to the game state on the backend. This flag is set to `true` when the pitcher's action resolves the at-bat and `false` otherwise.

The frontend `GameView.vue` component now uses this flag to determine whether to apply the 900ms delay or to display the result immediately. The flag is also reset correctly at the start of a new at-bat.