### PR TITLE
I have modified the CSS in `apps/frontend/src/components/GlobalNav.vu…

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -83,14 +83,8 @@ const isGamePage = computed(() => route.name === 'game');
 
   .nav-center {
     flex-grow: 1;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: none; /* For Firefox */
-    min-width: 0;
-  }
-
-  .nav-center::-webkit-scrollbar {
-      display: none; /* For Chrome, Safari, and Opera */
+    /* By removing overflow-x and min-width, the container will expand to fit its content (the linescore)
+       instead of scrolling internally. This allows the entire nav bar to become scrollable on the page level. */
   }
 
   .nav-left {


### PR DESCRIPTION
…e` to allow the navigation bar to expand with its content on mobile devices. I removed the properties that caused internal scrolling.