### PR TITLE
fix(css): Ensure content wrapper fills viewport height

### DIFF
--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -22,5 +22,6 @@ const authStore = useAuthStore();
 
   .main-content-wrapper {
     background-color: white; /* White background for the content area */
+    min-height: 100vh;
   }
 </style>


### PR DESCRIPTION
On mobile devices, the dark gray body background was bleeding into the `GameView` page because the main content wrapper was not tall enough to fill the screen.

This change adds `min-height: 100vh` to the `.main-content-wrapper` in `App.vue`. This ensures the wrapper always extends to the full height of the viewport, preventing the body background from showing through on pages with short content.