### PR TITLE
feat: Ensure returning players can see completed at-bat results

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -586,6 +586,17 @@ const outcomeBatter = computed(() => {
 onMounted(async () => {
   await gameStore.fetchGame(gameId);
   initialLoadComplete.value = true;
+
+  // NEW: Check if we are returning to a completed at-bat
+  const atBat = atBatToDisplay.value;
+  if (atBat && atBat.swingRollResult && atBat.pitchRollResult) {
+    const isOffensiveAndHasNotRolled = amIOffensivePlayer.value && !haveIRolledForSwing.value;
+    if (!isOffensiveAndHasNotRolled) {
+      isSwingResultVisible.value = true;
+      hasSeenResult.value = true;
+      localStorage.setItem(seenResultStorageKey, 'true');
+    }
+  }
   
   // --- THIS IS THE DEBUG LOG ---
   console.log('--- GameView Mounted: Checking Store Data ---');


### PR DESCRIPTION
Implements a check in the `onMounted` lifecycle hook of `GameView.vue`. This new logic addresses the scenario where a player returns to the game after an at-bat has already been completed and the game has advanced.

Previously, if a player was not viewing the page when the result was revealed and the game moved to the next batter, the UI would reset, hiding the result of the at-bat they participated in.

This change ensures that if the at-bat to be displayed is already complete (both pitch and swing results are present), the swing result is made visible immediately upon the component loading. This provides a better user experience for players who may be momentarily away from the application.