### PR TITLE
fix: resolve initialization error in GameView.vue

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -521,6 +521,11 @@ watch(infieldIn, (newValue) => {
 
 });
 
+const bothPlayersCaughtUp = computed(() => {
+if (!gameStore.gameState) return false;
+return !gameStore.gameState.awayPlayerReadyForNext && !gameStore.gameState.homePlayerReadyForNext
+});
+
 watch(batterToDisplay, (newBatter, oldBatter) => {
   const newName = newBatter ? newBatter.name : 'null';
   const oldName = oldBatter ? oldBatter.name : 'null';
@@ -575,11 +580,6 @@ const defensiveTeamKey = computed(() => gameStore.gameState?.isTopInning ? 'home
 const defensiveNextBatterIndex = computed(() => {
     if (!gameStore.gameState) return -1;
     return gameStore.gameState[defensiveTeamKey.value].battingOrderPosition;
-});
-
-const bothPlayersCaughtUp = computed(() => {
-if (!gameStore.gameState) return false;
-return !gameStore.gameState.awayPlayerReadyForNext && !gameStore.gameState.homePlayerReadyForNext
 });
 
 


### PR DESCRIPTION
Reordered the `bothPlayersCaughtUp` computed property to be declared before it is used in a watcher, fixing a 'Cannot access before initialization' ReferenceError.