### PR TITLE
fix(game): resolve multiple run-scoring display issues

### DIFF
--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -10,7 +10,7 @@ const linescore = computed(() => {
   const scores = { away: [], home: [] };
 
   // Use the direct store state: gameEvents, not gameEventsToDisplay
-  if (!gameStore.gameEvents || !gameStore.gameState) {
+  if (!gameStore.gameEventsToDisplay || !gameStore.gameState) {
     return { innings, scores };
   }
 
@@ -20,11 +20,14 @@ const linescore = computed(() => {
   let inningMarkersFound = 0;
 
   // Use the direct store state: gameEvents, not gameEventsToDisplay
-  gameStore.gameEvents.forEach(event => {
+  gameStore.gameEventsToDisplay.forEach(event => {
     if (typeof event.log_message === 'string') {
         if (event.log_message.includes('scores!')) {
-          if (isTop) { awayRunsInInning++; } 
-          else { homeRunsInInning++; }
+          // New logic to parse multi-run plays
+          const runsMatch = event.log_message.match(/\((\d+) runs\)/);
+          const runsScored = runsMatch ? parseInt(runsMatch[1], 10) : 1;
+          if (isTop) { awayRunsInInning += runsScored; }
+          else { homeRunsInInning += runsScored; }
         }
         else if (event.log_message.includes('---')) {
           if (inningMarkersFound > 0) {

--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -330,11 +330,25 @@ async function resetRolls(gameId) {
 
 // --- ADD THIS LINE ---
   const displayOuts = ref(0);
+  const isOutcomeHidden = ref(false);
 
   // --- ADD THIS ACTION ---
   function setDisplayOuts(count) {
     displayOuts.value = count;
   }
+
+  function setOutcomeHidden(value) {
+    isOutcomeHidden.value = value;
+  }
+
+  const gameEventsToDisplay = computed(() => {
+    if (!gameEvents.value) return [];
+    if (isOutcomeHidden.value) {
+      // The backend guarantees the last event is the one to hide
+      return gameEvents.value.slice(0, gameEvents.value.length - 1);
+    }
+    return gameEvents.value;
+  });
 
 
   function updateGameData(data) {
@@ -351,7 +365,7 @@ async function resetRolls(gameId) {
 
   return { game, gameState, gameEvents, batter, pitcher, lineups, rosters, setupState, teams,
     fetchGame, declareHomeTeam,setGameState,initiateSteal,resolveSteal,submitPitch, submitSwing, fetchGameSetup, submitRoll, submitGameSetup,submitTagUp,
-    displayOuts, setDisplayOuts,
+    displayOuts, setDisplayOuts, isOutcomeHidden, setOutcomeHidden, gameEventsToDisplay,
     submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls,
     updateGameData };
 })


### PR DESCRIPTION
- Linescore does not update when outcome is hidden.
  - The `shouldIHideOutcome` logic is centralized in the game store. The linescore and game log now respect this flag, preventing premature score reveals.
- Inning-by-inning score calculation is corrected.
  - The linescore now parses the number of runs from the event log to correctly display the runs scored in each inning, fixing an issue where multi-run plays were only counted as one run.
- Score update notification is restyled.
  - The notification now displays with black text, and only the score of the team that just scored is highlighted in red for better visibility.