### PR TITLE
fix: Adjust team header layout on mobile

### DIFF
--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -184,5 +184,15 @@ onUnmounted(() => {
 .game-list li a:hover { background-color: #f0f0f0; }
 .status { text-transform: capitalize; color: #555; }
 .turn-indicator { font-weight: bold; color: #28a745; }
+
+@media (max-width: 768px) {
+  .team-header {
+    flex-direction: column;
+    text-align: center;
+  }
+  .team-info h1 {
+    font-size: 2rem;
+  }
+}
 </style>
 


### PR DESCRIPTION
The team header on the dashboard now uses a column layout on screens smaller than 768px. This prevents long team names from breaking the layout and improves readability on mobile devices.