### PR TITLE
fix(game): Reset swing roll state on 'Next Hitter' click

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -320,8 +320,6 @@ watch(bothPlayersSetAction, (isRevealing) => {
     isSwingResultVisible.value = false;
     hasSeenResult.value = false;
     localStorage.removeItem(seenResultStorageKey);
-    haveIRolledForSwing.value = false;
-    localStorage.removeItem(rollStorageKey);
   }
 }, { immediate: true });
 
@@ -466,6 +464,8 @@ function handleNextHitter() {
   if (!opponentReadyForNext.value) {
     anticipatedBatter.value = nextBatterInLineup.value;
   }
+  haveIRolledForSwing.value = false;
+  localStorage.removeItem(rollStorageKey);
   gameStore.nextHitter(gameId);
 }
 


### PR DESCRIPTION
The `haveIRolledForSwing` state and its corresponding localStorage item were previously being reset in a `watch` block that observed a global state change (`bothPlayersSetAction`). This caused a bug where the state would persist incorrectly across at-bats for the offensive player.

This commit moves the reset logic directly into the `handleNextHitter()` function. This ensures that the state is correctly cleared at the exact moment the user clicks the 'Next Hitter' button, aligning the state update with the user's action and fixing the bug.