### PR TITLE
feat: Pre-cache next player card image

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -365,6 +365,14 @@ const nextBatterInLineup = computed(() => {
   return offensiveLineup[nextIndex]?.player;
 });
 
+// Pre-cache the next batter's image
+watch(nextBatterInLineup, (newNextBatter) => {
+  if (newNextBatter && newNextBatter.image_url) {
+    const img = new Image();
+    img.src = newNextBatter.image_url;
+  }
+}, { immediate: true });
+
 const batterToDisplay = computed(() => {
     if (anticipatedBatter.value) {
         return anticipatedBatter.value;


### PR DESCRIPTION
To improve performance and reduce the loading time when switching between player cards, this change introduces a pre-caching mechanism.

A watcher has been added to `GameView.vue` that monitors the `nextBatterInLineup` computed property. When the next batter is determined, their card image is downloaded in the background. This ensures that when the user clicks 'Next Hitter', the image is already in the browser's cache, resulting in a seamless and faster transition.