### PR TITLE
feat: Correctly display outs and linescore during inning change

### DIFF
--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -40,7 +40,9 @@ const linescore = computed(() => {
     }
   });
   
-  if (isTop) {
+  if (gameStore.isBetweenHalfInnings) {
+    // In this specific state, don't add the optimistic '0' for the next inning
+  } else if (isTop) {
     scores.away.push(awayRunsInInning);
   } else {
     if(scores.away.length === scores.home.length) {

--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -331,10 +331,15 @@ async function resetRolls(gameId) {
 // --- ADD THIS LINE ---
   const displayOuts = ref(0);
   const isOutcomeHidden = ref(false);
+  const isBetweenHalfInnings = ref(false);
 
   // --- ADD THIS ACTION ---
   function setDisplayOuts(count) {
     displayOuts.value = count;
+  }
+
+  function setIsBetweenHalfInnings(value) {
+    isBetweenHalfInnings.value = value;
   }
 
   function setOutcomeHidden(value) {
@@ -366,6 +371,7 @@ async function resetRolls(gameId) {
   return { game, gameState, gameEvents, batter, pitcher, lineups, rosters, setupState, teams,
     fetchGame, declareHomeTeam,setGameState,initiateSteal,resolveSteal,submitPitch, submitSwing, fetchGameSetup, submitRoll, submitGameSetup,submitTagUp,
     displayOuts, setDisplayOuts, isOutcomeHidden, setOutcomeHidden, gameEventsToDisplay,
+    isBetweenHalfInnings, setIsBetweenHalfInnings,
     submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls,
     updateGameData };
 })

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -419,6 +419,9 @@ const basesToDisplay = computed(() => {
 });
 
 const outsToDisplay = computed(() => {
+  if (gameStore.isBetweenHalfInnings) {
+    return 3;
+  }
   if (shouldHidePlayOutcome.value) {
     if (opponentReadyForNext.value) {
       return gameStore.gameState?.lastCompletedAtBat?.outsBeforePlay || 0;
@@ -437,6 +440,20 @@ watch(outsToDisplay, (newOuts) => {
     gameStore.setDisplayOuts(newOuts);
   }
 }, { immediate: true }); // 'immediate' runs the watcher once on component load
+
+
+const isBetweenHalfInnings = computed(() => {
+  if (!gameStore.gameState || !gameStore.gameState.lastCompletedAtBat) {
+    return false;
+  }
+  // State is true if the half-inning has flipped and the current player hasn't moved on
+  return !amIReadyForNext.value &&
+         gameStore.gameState.lastCompletedAtBat.isTopInning !== gameStore.gameState.isTopInning;
+});
+
+watch(isBetweenHalfInnings, (newValue) => {
+  gameStore.setIsBetweenHalfInnings(newValue);
+}, { immediate: true });
 
 
 function hexToRgba(hex, alpha = 1) {


### PR DESCRIPTION
This commit addresses an issue where the line score would display "Outs: 0" and a yellow "0" for the upcoming half-inning after an inning change but before the user clicked "Next Hitter".

The following changes have been made:
- A new state, `isBetweenHalfInnings`, has been added to the `game` store to track this specific UI state.
- The `GameView` now correctly identifies this state and updates the store.
- The `outsToDisplay` computed property in `GameView` now shows "3" when `isBetweenHalfInnings` is true.
- The `Linescore` component now checks for this state and hides the upcoming inning's score, preventing the yellow "0" from appearing.

This ensures that the UI accurately reflects the state of the game during the transition between half-innings.