### PR TITLE
fix(mobile): Set body background to white on mobile

### DIFF
--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -24,4 +24,10 @@ const authStore = useAuthStore();
     background-color: white; /* White background for the content area */
     min-height: 100vh;
   }
+
+  @media (max-width: 768px) {
+    body {
+      background-color: #fff; /* White background for mobile */
+    }
+  }
 </style>


### PR DESCRIPTION
On mobile devices, the dark grey body background was visible behind the main content area. This change adds a media query to set the body background to white on screens with a max-width of 768px, resolving the issue.