### PR TITLE
feat: Move OutsDisplay next to Linescore

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -23,13 +23,13 @@ const isGamePage = computed(() => route.name === 'game');
     
     <div class="nav-center">
       <Linescore v-if="isGamePage && gameStore.gameState && gameStore.gameEvents.length > 0" />
-    </div>
-
-    <div class="nav-right">
       <OutsDisplay
         v-if="isGamePage && gameStore.gameState"
         :outs="gameStore.displayOuts"
       />
+    </div>
+
+    <div class="nav-right">
       <button class="logout-button" @click="authStore.logout()">Logout</button>
     </div>
   </nav>
@@ -74,6 +74,12 @@ const isGamePage = computed(() => route.name === 'game');
   width: auto;  
   border-radius: 4px;
   display: block;
+}
+
+.nav-center {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
 }
 
 .nav-right {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
       ]
     },
     "apps/backend": {
-      "name": "showdown-league-app",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -4086,6 +4085,10 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/backend": {
+      "resolved": "apps/backend",
+      "link": true
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
@@ -5349,10 +5352,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/showdown-league-app": {
-      "resolved": "apps/backend",
-      "link": true
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",


### PR DESCRIPTION
Moves the OutsDisplay component to be to the right of the Linescore component in the center of the navigation bar.

This improves the layout by grouping related game information together.