### PR TITLE
feat: Display detailed game state on dashboard

### DIFF
--- a/apps/frontend/src/components/GameScorecard.vue
+++ b/apps/frontend/src/components/GameScorecard.vue
@@ -1,0 +1,95 @@
+<script setup>
+import { computed } from 'vue';
+import BaseballDiamond from './BaseballDiamond.vue';
+import OutsDisplay from './OutsDisplay.vue';
+
+const props = defineProps({
+  game: {
+    type: Object,
+    required: true,
+  },
+});
+
+const gameState = computed(() => props.game.gameState);
+
+const inningDescription = computed(() => {
+  if (!gameState.value) return '';
+  const inningHalf = gameState.value.isTopInning ? 'Top' : 'Bottom';
+  const inningNumber = gameState.value.inning;
+  return `${inningHalf} ${inningNumber}`;
+});
+</script>
+
+<template>
+  <div class="game-scorecard">
+    <div class="opponent-info">
+      <span v-if="game.opponent">vs. {{ game.opponent.full_display_name }}</span>
+      <span v-else>Waiting for opponent...</span>
+    </div>
+
+    <div v-if="game.status === 'in_progress' && gameState" class="game-details">
+      <div class="score-inning">
+        <div class="score">
+          <span>AWAY: {{ gameState.awayScore }}</span>
+          <span>HOME: {{ gameState.homeScore }}</span>
+        </div>
+        <div class="inning">{{ inningDescription }}</div>
+      </div>
+      <div class="game-state">
+        <BaseballDiamond :runners="gameState.bases" />
+        <OutsDisplay :outs="gameState.outs" />
+      </div>
+    </div>
+    <div v-else class="game-status">
+       <span class="status">{{ game.status }}</span>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.game-scorecard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+.opponent-info {
+  font-weight: bold;
+}
+
+.game-details {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.score-inning {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.score {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.9rem;
+}
+
+.inning {
+  font-style: italic;
+  font-size: 0.9rem;
+}
+
+.game-state {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.game-status {
+    text-transform: capitalize;
+    color: #555;
+    font-style: italic;
+}
+</style>

--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -3,6 +3,7 @@ import { onMounted, onUnmounted, computed } from 'vue';
 import { useAuthStore } from '@/stores/auth';
 import { RouterLink, useRouter } from 'vue-router';
 import { socket } from '@/services/socket';
+import GameScorecard from '@/components/GameScorecard.vue';
 
 const authStore = useAuthStore();
 const router = useRouter();
@@ -84,12 +85,8 @@ onUnmounted(() => {
         <ul v-if="authStore.myGames.length > 0" class="game-list">
             <li v-for="game in authStore.myGames" :key="game.game_id">
                 <RouterLink :to="game.status === 'pending' ? `/game/${game.game_id}/setup` : (game.status === 'lineups' ? `/game/${game.game_id}/lineup` : `/game/${game.game_id}`)">
-                    <!-- This now displays the opponent's team name -->
-                    <span v-if="game.opponent">vs. {{ game.opponent.full_display_name }}</span>
-                    <span v-else>Waiting for opponent...</span>
-                    
-                    <span class="status">{{ game.status }}</span>
-                    <span v-if="game.status === 'in_progress' && Number(game.current_turn_user_id) === authStore.user?.userId" class="turn-indicator">
+                    <GameScorecard :game="game" />
+                    <span v-if="Number(game.current_turn_user_id) === authStore.user?.userId" class="turn-indicator">
                         Your Turn!
                     </span>
                 </RouterLink>


### PR DESCRIPTION
This commit enhances the user dashboard to provide more detailed information for in-progress games.

- The `/api/games` backend endpoint has been updated to include the latest game state (score, inning, outs, bases) for any game with a status of 'in_progress'.

- A new `GameScorecard.vue` component has been created to display this detailed information in a structured format, reusing existing components like `BaseballDiamond` and `OutsDisplay`.

- The `DashboardView.vue` has been modified to use the `GameScorecard.vue` component, replacing the previous simple status display.

- The "Your Turn!" indicator logic is now correctly displayed whenever it's the user's turn to act, regardless of the game's status, improving feedback for the user.