### PR TITLE
fix: Reset game state on unmount

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -368,10 +368,27 @@ async function resetRolls(gameId) {
     if (data.teams) teams.value = data.teams;
   }
 
+  function resetGameState() {
+    game.value = null;
+    gameState.value = null;
+    gameEvents.value = [];
+    batter.value = null;
+    pitcher.value = null;
+    lineups.value = { home: null, away: null };
+    rosters.value = { home: [], away: [] };
+    teams.value = { home: null, away: null };
+    setupState.value = null;
+    displayOuts.value = 0;
+    isOutcomeHidden.value = false;
+    isBetweenHalfInnings.value = false;
+  }
+
   return { game, gameState, gameEvents, batter, pitcher, lineups, rosters, setupState, teams,
     fetchGame, declareHomeTeam,setGameState,initiateSteal,resolveSteal,submitPitch, submitSwing, fetchGameSetup, submitRoll, submitGameSetup,submitTagUp,
     displayOuts, setDisplayOuts, isOutcomeHidden, setOutcomeHidden, gameEventsToDisplay,
     isBetweenHalfInnings, setIsBetweenHalfInnings,
     submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls,
-    updateGameData };
+    updateGameData,
+    resetGameState
+  };
 })

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -774,6 +774,7 @@ onMounted(async () => {
 });
 
 onUnmounted(() => {
+  gameStore.resetGameState();
   socket.off('game-updated');
   socket.disconnect();
 });


### PR DESCRIPTION
Resets the Pinia game store state when the GameView component is unmounted.

This prevents stale data from a previous game, such as the linescore, from being displayed when a user starts a new game. A `resetGameState` action was added to the game store and is called from the `onUnmounted` lifecycle hook in `GameView.vue`.