### PR TITLE
fix(frontend): Prevent crash in BaseballDiamond component

### DIFF
--- a/apps/frontend/src/components/BaseballDiamond.vue
+++ b/apps/frontend/src/components/BaseballDiamond.vue
@@ -11,7 +11,7 @@ const emit = defineEmits(['attempt-steal']);
 </script>
 
 <template>
-  <div class="diamond-container">
+  <div v-if="bases" class="diamond-container">
     <!-- Runner slots are now absolutely positioned divs -->
     <div class="runner-slot" style="top: 48%; left: 78%;">
       <RunnerCard v-if="bases.first" :runner="bases.first" />

--- a/apps/frontend/src/components/GameScorecard.vue
+++ b/apps/frontend/src/components/GameScorecard.vue
@@ -36,7 +36,7 @@ const inningDescription = computed(() => {
         <div class="inning">{{ inningDescription }}</div>
       </div>
       <div class="game-state">
-        <BaseballDiamond :runners="gameState.bases" />
+        <BaseballDiamond :bases="gameState.bases" />
         <OutsDisplay :outs="gameState.outs" />
       </div>
     </div>


### PR DESCRIPTION
This commit fixes a rendering crash on the dashboard caused by the `BaseballDiamond` component.

The `GameScorecard` component was passing a prop named `runners` to the `BaseballDiamond` component, but the component expected a prop named `bases`. This mismatch resulted in the `bases` prop being undefined, causing a `TypeError` when the component's template attempted to access its properties.

The fix involves two changes:
1.  In `GameScorecard.vue`, the prop name has been corrected from `runners` to `bases`.
2.  In `BaseballDiamond.vue`, a `v-if="bases"` directive has been added to the root element to prevent the component from rendering if the `bases` prop is not a valid object. This makes the component more robust and prevents similar crashes in the future.