### PR TITLE
fix(frontend): Correct mobile layout issues in game view

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -91,34 +91,26 @@ const isGamePage = computed(() => route.name === 'game');
 @media (max-width: 768px) {
   .global-nav {
     padding: 0.5rem;
-    gap: 1rem;
+    gap: 0.5rem; /* Reduced gap for tighter fit */
   }
 
-  .nav-left, .nav-right {
+  .nav-left {
+    flex-shrink: 0; /* Prevent logo from shrinking */
+    flex-basis: auto;
+  }
+
+  .nav-right {
     flex-shrink: 0;
   }
 
   .nav-center {
-    flex-grow: 1;
-    min-width: 0; /* Allows the container to shrink */
-    /* ADDED: These properties help center the scaled content */
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    flex-grow: 1; /* Allow this to fill available space */
+    min-width: 0; /* Critical for flex-grow in a flex container */
+    justify-content: space-between; /* Pushes Linescore and Outs apart */
   }
 
-  /* ADDED: This is the shrinking magic.
-    :deep() allows this component's styles to affect its direct child (Linescore).
-    We are scaling the Linescore component down to 85% of its original size.
-  */
-  .nav-center :deep(> *) {
-    transform: scale(0.85);
-    transform-origin: center;
-  }
-
-  .nav-left {
-      flex-basis: auto;
-  }
+  /* REMOVED: The transform was causing the overlap issue.
+     Flexbox properties now handle the layout. */
 
   .dashboard-link-text {
     display: none;
@@ -126,6 +118,11 @@ const isGamePage = computed(() => route.name === 'game');
   
   .global-nav.game-page-active .logout-button {
     display: none;
+  }
+
+  /* Ensure the outs are visible against the dark background */
+  .nav-center :deep(.outs-display) {
+    background-color: transparent; /* Or whatever matches the nav */
   }
 }
 </style>

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -1030,37 +1030,35 @@ onUnmounted(() => {
 /* --- MOBILE LAYOUT (FLEXBOX) --- */
 @media (max-width: 992px) {
   .at-bat-container {
-    display: flex; /* Override grid */
-    flex-direction: column;
-    align-items: center;
-    gap: 1.5rem; /* Add some space between reordered items */
-  }
-
-  /* Make containers actual flex items again */
-  .player-cards-and-actions-container {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 1.5rem;
-    order: 1; /* Default, but explicit */
-    width: 100%;
+  }
+
+  /* This is the key change. By using 'display: contents', we make the children
+     of this container direct flex items of '.at-bat-container', which allows
+     us to reorder them freely. */
+  .player-cards-and-actions-container {
+    display: contents;
   }
 
   /* Reorder the items for mobile */
-  .diamond-and-results-container {
-    order: 1; /* Diamond appears FIRST */
-  }
-  .player-cards-wrapper {
-    order: 2; /* Player cards appear SECOND */
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    width: 100%;
-  }
   .actions-container {
-    order: 3; /* Action buttons appear LAST */
+    order: 1; /* Action buttons appear FIRST */
     width: 100%;
     max-width: 350px;
+  }
+  .diamond-and-results-container {
+    order: 2; /* Diamond appears SECOND */
+  }
+  .player-cards-wrapper {
+    order: 3; /* Player cards appear LAST */
+    display: flex;
+    gap: 1rem;
+    justify-content: center; /* This will now correctly center the cards */
+    width: 100%;
+    flex-wrap: wrap; /* Ensure cards wrap on very small screens */
   }
 
   /* Reset grid-specific properties */

--- a/jules-scratch/verification/verify_mobile_layout.py
+++ b/jules-scratch/verification/verify_mobile_layout.py
@@ -1,21 +1,65 @@
-import re
+import json
 from playwright.sync_api import sync_playwright, expect
 
 def run(playwright):
-    # Set a mobile viewport
-    iphone_13_pro = playwright.devices['iPhone 13 Pro']
-    browser = playwright.chromium.launch(headless=True)
-    context = browser.new_context(**iphone_13_pro)
-    page = context.new_page()
+    # --- DUMMY AUTH DATA ---
+    # This mimics the data stored in localStorage by the real auth store
+    user = {
+        "userId": 1,
+        "email": "jules@test.com",
+        "team": {
+            "team_id": 1,
+            "abbreviation": "BOS",
+            "logo_url": "/images/logos/red_sox.png"
+        }
+    }
+    # The token doesn't have to be valid, it just needs to exist
+    token = "dummy-token"
 
-    # Navigate directly to the game view
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+
+    # --- SET UP AUTH BEFORE NAVIGATION ---
+    # Go to the base URL to establish a context for localStorage
+    page = context.new_page()
+    page.goto("http://localhost:5173/")
+
+    # Set the localStorage items for the correct origin
+    page.evaluate(f"""
+        localStorage.setItem('token', '{token}');
+        localStorage.setItem('user', '{json.dumps(user)}');
+    """)
+
+    # --- NAVIGATE TO THE DEV TOOL ---
+    # Now navigate to the dev tool page for an existing game
+    # The auth state is already set, so we should bypass the login
+    page.goto("http://localhost:5173/dev-tool/1")
+
+    # --- SET UP GAME STATE ---
+    # Click buttons to get the game into a playable state
+    # Use locators that are robust (e.g., get_by_role)
+    reset_button = page.get_by_role("button", name="Reset Game")
+    start_button = page.get_by_role("button", name="Start Game")
+
+    # Wait for the buttons to be ready and click them
+    expect(reset_button).to_be_enabled()
+    reset_button.click()
+    expect(start_button).to_be_enabled()
+    start_button.click()
+
+    # --- NAVIGATE TO THE GAME AND TAKE SCREENSHOT ---
+    # Now that the game is set up, go to the actual game view
     page.goto("http://localhost:5173/game/1")
 
-    # Add a delay to allow Vue to render with mock data
-    page.wait_for_timeout(2000) # 2 seconds should be enough
+    # Set viewport to a typical mobile size to test the responsive layout
+    page.set_viewport_size({"width": 375, "height": 812})
 
-    # Take screenshot for debugging
-    page.screenshot(path="jules-scratch/verification/debug_mock_render.png")
+    # Wait for a key element to be visible to ensure the page has loaded
+    # The baseball diamond is a good indicator
+    expect(page.locator('.baseball-diamond')).to_be_visible()
+
+    # Take a screenshot for visual verification
+    page.screenshot(path="jules-scratch/verification/mobile_layout_fix.png")
 
     browser.close()
 


### PR DESCRIPTION
This commit addresses several layout problems on the mobile version of the game page:

- **GlobalNav.vue:**
  - Adjusted flexbox properties in the mobile media query to prevent the linescore from overlapping the team logo.
  - Ensured the central navigation element expands correctly to fill space, removing the whitespace issue on the right side when the logout button is hidden.
  - Removed a `transform: scale()` property that was causing layout conflicts.

- **GameView.vue:**
  - Modified the mobile CSS to use `display: contents` on the `player-cards-and-actions-container`. This flattens the flexbox structure, allowing for independent ordering of its children.
  - Reordered the elements using the `order` property to place the action buttons above the baseball diamond.
  - Corrected the styling for the player card wrapper to ensure it centers properly on the screen.