### PR TITLE
fix(frontend): Resolve mobile layout issues for player cards and toolbar

### DIFF
--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -6,28 +6,26 @@ const authStore = useAuthStore();
 </script>
 
 <template>
-  <GlobalNav v-if="authStore.isAuthenticated" />
-  <div class="main-content-wrapper">
-    <RouterView />
+  <div class="app-wrapper">
+    <GlobalNav v-if="authStore.isAuthenticated" />
+    <div class="main-content-wrapper">
+      <RouterView />
+    </div>
   </div>
 </template>
 
 <style>
+  .app-wrapper {
+    background-color: #343a40;
+  }
   /* Global styles for the entire application */
   body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
     margin: 0;
-    background-color: #343a40; /* Dark background for the whole page */
   }
 
   .main-content-wrapper {
     background-color: white; /* White background for the content area */
     min-height: 100vh;
-  }
-
-  @media (max-width: 768px) {
-    body {
-      background-color: #fff; /* White background for mobile */
-    }
   }
 </style>

--- a/apps/frontend/src/components/PlayerCard.vue
+++ b/apps/frontend/src/components/PlayerCard.vue
@@ -79,7 +79,6 @@ function formatRange(range) {
   aspect-ratio: 220 / 308;
 
   position: relative;
-  height: 272px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
   border-radius: 12px;
   overflow: hidden;

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -1071,6 +1071,9 @@ onUnmounted(() => {
     grid-row: auto;
     margin-top: 0;
   }
+  .player-container {
+    flex: 1 1 45%;
+  }
 }
 
 


### PR DESCRIPTION
This commit addresses two layout problems on the mobile view of the game screen.

First, the player cards were stacking vertically instead of appearing side-by-side. This was resolved by:
- Removing the fixed height on the `PlayerCard` component to allow it to be responsive.
- Applying a robust flexbox layout to the card container in `GameView`, ensuring the cards arrange themselves correctly in a row on mobile screens.

Second, the dark grey toolbar did not cover the entire top of the screen on mobile, leaving a white bar that made some text invisible. This was fixed by:
- Refactoring `App.vue` to wrap the application in a container with a consistent dark background. This provides a robust solution without relying on global body styles, ensuring the toolbar always has the correct background.

These changes significantly improve the user experience on mobile devices.