### PR TITLE
Fix: Prevent ReferenceError in Linescore component

### DIFF
--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -46,7 +46,10 @@ const linescore = computed(() => {
     scores.away.push(awayRunsInInning);
   } else {
     if(scores.away.length === scores.home.length) {
-       scores.away.push(awayRunsInInning);
+      // When we're in the bottom of an inning, the away team's runs for this inning are final.
+      // The awayRunsInning variable should have been reset to 0 by the last inning-change event.
+      // Pushing 0 is the correct action.
+      scores.away.push(0);
     }
     scores.home.push(homeRunsInInning);
   }


### PR DESCRIPTION
In `Linescore.vue`, a `ReferenceError` for the `awayRunsInning` variable would occur when the game transitioned to the bottom of the first inning. This was because the logic to add the away team's score for the inning was attempting to access a variable that was out of scope in that specific code path.

This commit fixes the issue by replacing the variable with a literal `0`. When the game is in the bottom of an inning, the away team's score for that inning is final, and if they haven't scored, it should be 0. This change is logically equivalent and prevents the component from crashing.