### PR TITLE
fix(css): Constrain Linescore component to prevent nav overflow on mo…

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -123,6 +123,12 @@ const isGamePage = computed(() => route.name === 'game');
   /* Ensure the outs are visible against the dark background */
   .nav-center :deep(.outs-display) {
     background-color: transparent; /* Or whatever matches the nav */
+    flex-shrink: 0;
+  }
+
+  .nav-center :deep(.linescore-container) {
+    flex: 1 1 0;
+    min-width: 0;
   }
 }
 </style>

--- a/jules-scratch/verification/verify_nav_fix.py
+++ b/jules-scratch/verification/verify_nav_fix.py
@@ -1,0 +1,65 @@
+import re
+from playwright.sync_api import Page, expect, sync_playwright
+import random
+import string
+
+def random_string(length=10):
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(length))
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context(
+        viewport={'width': 375, 'height': 812},
+        is_mobile=True,
+        user_agent='Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1'
+    )
+    page = context.new_page()
+
+    # Registration
+    email = f"testuser_{random_string()}@example.com"
+    password = "password123"
+
+    page.goto("http://localhost:5173/register")
+
+    page.get_by_label("Email").fill(email)
+    page.get_by_label("Password").fill(password)
+    page.get_by_label("First Name").fill("Test")
+    page.get_by_label("Last Name").fill("User")
+
+    # Select the first available team
+    page.get_by_label("Choose a Team").select_option(index=1)
+
+    page.get_by_role("button", name="Register").click()
+
+    # Wait for registration to complete and redirect to login
+    expect(page).to_have_url(re.compile(".*login"))
+
+    # Login
+    page.get_by_label("Email").fill(email)
+    page.get_by_label("Password").fill(password)
+    page.get_by_role("button", name="Login").click()
+
+    # Wait for login to complete and redirect to dashboard
+    expect(page).to_have_url(re.compile(".*dashboard"))
+
+    # Navigate to a game - this requires a game to exist.
+    # Since we can't create one easily, we'll just check the dashboard for now.
+    # The key is to get to a page where the global nav is visible.
+    # The original bug was on the game page, so we'll simulate that by checking the dashboard,
+    # which also has the nav bar.
+
+    # A better approach if games were available would be to find and click a game link.
+    # For now, we assume the dashboard is sufficient to test the nav bar fix.
+    page.goto("http://localhost:5173/game/1") # Assume game 1 exists for visual test
+
+    # Wait for the nav to be visible
+    expect(page.locator(".global-nav")).to_be_visible()
+
+    # Take a screenshot to verify the fix
+    page.screenshot(path="jules-scratch/verification/verification.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
…bile

On mobile viewports, the `Linescore` component could grow wider than the screen, causing its flex container (`.nav-center`) to overflow. This pushed the entire `.global-nav` to be wider than the viewport, resulting in its background being cut off on the right side.

This change adds CSS rules to the mobile media query in `GlobalNav.vue`:
- The `Linescore` container is given `flex: 1 1 0` and `min-width: 0` to make it flexible and allow it to shrink and contain its overflowing content with a scrollbar.
- The `OutsDisplay` is given `flex-shrink: 0` to ensure it is not compressed and remains visible.

This resolves the visual bug by ensuring the navigation bar correctly fits the screen width.