### PR TITLE
Fix: Correct Available Games pane display and functionality

### DIFF
--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -86,9 +86,6 @@ onUnmounted(() => {
             <li v-for="game in authStore.myGames" :key="game.game_id">
                 <RouterLink :to="game.status === 'pending' ? `/game/${game.game_id}/setup` : (game.status === 'lineups' ? `/game/${game.game_id}/lineup` : `/game/${game.game_id}`)">
                     <GameScorecard :game="game" />
-                    <span v-if="Number(game.current_turn_user_id) === authStore.user?.userId" class="turn-indicator">
-                        Your Turn!
-                    </span>
                 </RouterLink>
             </li>
         </ul>


### PR DESCRIPTION
This commit addresses several issues in the "Available Games" component:

- **Fixes Blank Game Card Bug:** New games now display correctly with a "Waiting for opponent" message instead of a blank card, allowing users to proceed with game setup. This was resolved by adding pre-game state handling in `GameScorecard.vue` and ensuring the backend provides necessary data.
- **Displays Team Abbreviations:** The component now shows correct team abbreviations (e.g., "DET", "BOS") instead of "AWAY" and "HOME". The backend `/api/games` endpoint was updated to include team abbreviations in the response.
- **Corrects Layout and Formatting:**
    - The game status message ("Your Turn!", etc.) is now correctly positioned on the left side of the second line.
    - A comma is now properly displayed between the base-running status and the outs count.
- **Refactors Status Logic:** The "Your Turn!" display logic was centralized into the `GameScorecard.vue` component, removing redundant code from `DashboardView.vue`.