### PR TITLE
feat: Center linescore and outs display in global nav

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -41,7 +41,6 @@ const isGamePage = computed(() => route.name === 'game');
   background-color: #343a40;
   padding: 0.5rem 1rem;
   display: flex;
-  justify-content: space-between;
   align-items: center;
   position: sticky;
   top: 0;
@@ -80,6 +79,7 @@ const isGamePage = computed(() => route.name === 'game');
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  margin: 0 auto;
 }
 
 .nav-right {


### PR DESCRIPTION
This commit centers the linescore and outs display on the global navigation bar.

The previous implementation used `justify-content: space-between` on the parent container, which did not guarantee centering if the left and right elements had different widths.

This change removes the `justify-content` property from the parent and applies `margin: 0 auto` to the center element, ensuring it is always horizontally centered within the navigation bar.