### PR TITLE
feat: Hide second line in GameScorecard when waiting for opponent

### DIFF
--- a/apps/frontend/src/components/GameScorecard.vue
+++ b/apps/frontend/src/components/GameScorecard.vue
@@ -88,7 +88,7 @@ const statusText = computed(() => {
           <span class="inning">{{ inningDescription }}</span>
         </div>
       </div>
-      <div class="line-2">
+      <div class="line-2" v-if="game.opponent">
         <span class="status" v-if="isUsersTurn">Your Turn!</span>
         <span class="status not-your-turn" v-else>{{ statusText }}</span>
 


### PR DESCRIPTION
Conditionally renders the second line of the GameScorecard component only when an opponent has joined the game. This prevents a redundant status message from appearing for games that are waiting for an opponent.