### PR TITLE
Fix console errors during game start and navigation

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -371,11 +371,8 @@ app.post('/api/games/:gameId/lineup', authenticateToken, async (req, res) => {
 
       await client.query(`INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)`, [gameId, 1, initialGameState, false, false]);
       
-      const homeRosterCards = await client.query(`SELECT * FROM cards_player WHERE card_id = ANY(SELECT card_id FROM roster_cards WHERE roster_id = $1)`, [homeParticipant.roster_id]);
-      const startingPitcherCard = homeRosterCards.rows.find(c => c.card_id === homeParticipant.lineup.startingPitcher);
-      
       const allCardsResult = await pool.query('SELECT name, team FROM cards_player');
-      processPlayers([startingPitcherCard], allCardsResult.rows);
+      processPlayers([pitcher], allCardsResult.rows);
 
       const awayTeam = await client.query('SELECT * FROM teams WHERE user_id = $1', [awayParticipant.user_id]);
       const homeTeam = await client.query('SELECT * FROM teams WHERE user_id = $1', [homeParticipant.user_id]);
@@ -387,7 +384,7 @@ app.post('/api/games/:gameId/lineup', authenticateToken, async (req, res) => {
             <img src="${awayTeamLogo}" class="team-logo-small" alt="Team Logo">
             <b>Top 1st</b>
         </div>
-        <div class="pitcher-announcement">${homeTeamAbbr} Pitcher: ${startingPitcherCard.displayName}</div>
+        <div class="pitcher-announcement">${homeTeamAbbr} Pitcher: ${pitcher.displayName}</div>
       `;
       // --- ADD THIS LOG ---
     console.log(`🔫 SERVER: Creating initial event for game ${gameId}:`, inningChangeEvent);

--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -34,8 +34,8 @@ async function fetchGame(gameId) {
       
       
       game.value = data.game;
-      gameState.value = data.gameState.state_data;
-      gameEvents.value = data.gameEvents;
+      gameState.value = data.gameState?.state_data || null;
+      gameEvents.value = data.gameEvents || [];
       batter.value = data.batter;
       pitcher.value = data.pitcher;
       lineups.value = data.lineups;

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -171,6 +171,11 @@ const amIDefensivePlayer = computed(() => {
     return !amIOffensivePlayer.value;
 });
 
+const isBetweenHalfInnings = computed(() => {
+  if (!gameStore.gameState) return false;
+  return gameStore.gameState.isBetweenHalfInningsAway || gameStore.gameState.isBetweenHalfInningsHome;
+});
+
 // NEW: Display-only computeds for the inning changeover
 const amIDisplayOffensivePlayer = computed(() => {
   if (isBetweenHalfInnings.value) {
@@ -491,12 +496,6 @@ watch(outsToDisplay, (newOuts) => {
     gameStore.setDisplayOuts(newOuts);
   }
 }, { immediate: true }); // 'immediate' runs the watcher once on component load
-
-
-const isBetweenHalfInnings = computed(() => {
-  if (!gameStore.gameState) return false;
-  return gameStore.gameState.isBetweenHalfInningsAway || gameStore.gameState.isBetweenHalfInningsHome;
-});
 
 function hexToRgba(hex, alpha = 0.95) {
   if (!hex || !/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)) {


### PR DESCRIPTION
This commit addresses three separate errors that were preventing users from starting and viewing games correctly.

1.  **Fix Frontend Null Reference in `game.js`**: Modified the `fetchGame` action in the Pinia store to handle cases where `gameState` is `null` for a new game. It now uses optional chaining (`?.`) to safely access `state_data` and provides a default empty array for `gameEvents`, preventing the `TypeError` on the lineup page.

2.  **Fix Backend 500 Error in `server.js`**: Refactored the lineup submission route (`/api/games/:gameId/lineup`) to be more robust. Removed a redundant and fragile database lookup for the starting pitcher's card and instead reused the `pitcher` object that was already available. This resolves the 500 internal server error that occurred when the second player submitted their lineup.

3.  **Fix `GameView.vue` Initialization Error**: Resolved a `ReferenceError` in `GameView.vue` caused by a temporal dead zone issue. The `isBetweenHalfInnings` computed property was being accessed by other computed properties before it was defined. The fix involved reordering the definition of `isBetweenHalfInnings` to be before any of its dependents, ensuring the correct initialization order.