### PR TITLE
feat: Make Linescore component responsive on mobile

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -128,7 +128,7 @@ const isGamePage = computed(() => route.name === 'game');
     flex-shrink: 0;
   }
 
-  .nav-center :deep(.linescore-container) {
+  .nav-center :deep(.linescore-table) {
     flex: 1 1 0;
     min-width: 0;
   }

--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -125,5 +125,19 @@ const homeTeamAbbr = computed(() => gameStore.teams?.home?.abbreviation || 'HOME
   color: #ffc107;
   font-weight: bold;
 }
+
+@media (max-width: 768px) {
+  .linescore-table {
+    font-size: 0.9em;
+  }
+  .linescore-table th,
+  .linescore-table td {
+    min-width: unset;
+    padding: 0.1rem;
+  }
+  .linescore-table td:first-child {
+    min-width: unset;
+  }
+}
 </style>
 


### PR DESCRIPTION
The global navigation bar was too wide on mobile devices, causing a horizontal scrollbar to appear. This was caused by the `Linescore` component, which had a fixed minimum width for its table cells.

This change introduces a media query in `Linescore.vue` to make the table cells more compact on smaller screens. The `min-width` is removed, and padding and font size are reduced. This allows the `Linescore` component to shrink and fit within the available space.

The CSS selector in `GlobalNav.vue` has also been updated to correctly target the `linescore-table` after removing an unnecessary wrapper `div`.