### PR TITLE
fix: Add migration for inning transition flags

### DIFF
--- a/apps/backend/migrations/20250929165100_add_inning_transition_flags.js
+++ b/apps/backend/migrations/20250929165100_add_inning_transition_flags.js
@@ -1,0 +1,19 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = pgm => {
+  pgm.sql(`
+    ALTER TABLE "game_states"
+      ADD COLUMN IF NOT EXISTS "is_between_half_innings_home" BOOLEAN DEFAULT false,
+      ADD COLUMN IF NOT EXISTS "is_between_half_innings_away" BOOLEAN DEFAULT false;
+  `);
+};
+
+exports.down = pgm => {
+  pgm.sql(`
+    ALTER TABLE "game_states"
+      DROP COLUMN IF EXISTS "is_between_half_innings_home",
+      DROP COLUMN IF EXISTS "is_between_half_innings_away";
+  `);
+};


### PR DESCRIPTION
This commit fixes a bug that caused players to get stuck on the "Lineup Submitted!" screen.

The issue was caused by a missing database migration. The backend was trying to update the `is_between_half_innings_home` and `is_between_half_innings_away` columns in the `game_states` table, but these columns did not exist.

This commit adds a new database migration file to create the missing columns, resolving the server error and allowing the game to proceed after both players have submitted their lineups.