### PR TITLE
Fix: Add User-Agent to download-images.js

### DIFF
--- a/apps/backend/download-images.js
+++ b/apps/backend/download-images.js
@@ -54,6 +54,9 @@ async function downloadImage(url, filepath) {
     url,
     method: 'GET',
     responseType: 'stream',
+    headers: {
+      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+    }
   });
 
   response.data.pipe(writer);


### PR DESCRIPTION
The download-images.js script was failing with a 403 Forbidden error because the requests were missing a User-Agent header. This change adds a User-Agent header to the axios request to mimic a web browser, which should resolve the issue.