### PR TITLE
Fix: Correct image download URL generation in script

### DIFF
--- a/apps/backend/download-images.js
+++ b/apps/backend/download-images.js
@@ -41,7 +41,7 @@ function generateImageUrl(setName, cardNumber) {
   }
 
   if (imageId > 0) {
-    return `https://www.tcdb.com/Images/Large/Baseball/${setId}/${setId}-27${imageId}Fr.jpg`;
+    return `https://www.tcdb.com/Images/Cards/Baseball/${setId}/${setId}-${imageId}Fr.jpg`;
   }
   return null;
 }


### PR DESCRIPTION
The `download-images.js` script was failing with `403 Forbidden` errors because it was generating incorrect URLs for the card images from tcdb.com.

The URL generation logic was outdated. This commit updates the `generateImageUrl` function to use the correct URL format, which involves changing the path from `/Large/` to `/Cards/` and using a hyphen separator for the image ID.

This change allows the script to successfully download the high-quality images as intended.