### PR TITLE
fix(frontend): Resolve console errors on new game load

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -37,7 +37,7 @@ async function fetchGame(gameId) {
       game.value = data.game;
       
       series.value = data.series;
-      gameState.value = data.gameState.state_data;
+      gameState.value = data.gameState ? data.gameState.state_data : null;
       gameEvents.value = data.gameEvents;
       
       batter.value = data.batter;

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue';
-import { useRoute } from 'vue-router';
+import { useRoute, useRouter } from 'vue-router';
 import { useGameStore } from '@/stores/game';
 import { useAuthStore } from '@/stores/auth';
 import { socket } from '@/services/socket';


### PR DESCRIPTION
This commit addresses two critical errors that occurred when loading a new game, resulting in a blank screen.

1.  **`ReferenceError: useRouter is not defined` in `GameView.vue`**: The `useRouter` composable was being called without being imported from `vue-router`. The missing import has been added.

2.  **`TypeError: Cannot read properties of null (reading 'state_data')` in `stores/game.js`**: The `fetchGame` action was attempting to access `gameState.state_data` without verifying that `gameState` was not null. For newly created games, the API returns a null `gameState`, causing a crash. The code now includes a check to ensure `gameState` exists before accessing its properties, defaulting to null if it doesn't.