### PR TITLE
fix(frontend): Correct team colors between half-innings

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -179,6 +179,15 @@ const isBetweenHalfInnings = computed(() => {
   return gameStore.gameState.isBetweenHalfInningsAway || gameStore.gameState.isBetweenHalfInningsHome;
 });
 
+// NEW: A display-only computed to handle inning-change visuals
+const isDisplayTopInning = computed(() => {
+  if (!gameStore.gameState) return null;
+  if (isBetweenHalfInnings.value) {
+    return !gameStore.gameState.isTopInning;
+  }
+  return gameStore.gameState.isTopInning;
+});
+
 // NEW: Display-only computeds for the inning changeover
 const amIDisplayOffensivePlayer = computed(() => {
   if (isBetweenHalfInnings.value) {
@@ -332,8 +341,8 @@ const groupedGameLog = computed(() => {
   return groups.reverse();
 });
 
-const pitcherTeamColors = computed(() => gameStore.gameState?.isTopInning ? homeTeamColors.value : awayTeamColors.value);
-const batterTeamColors = computed(() => gameStore.gameState?.isTopInning ? awayTeamColors.value : homeTeamColors.value);
+const pitcherTeamColors = computed(() => isDisplayTopInning.value ? homeTeamColors.value : awayTeamColors.value);
+const batterTeamColors = computed(() => isDisplayTopInning.value ? awayTeamColors.value : homeTeamColors.value);
 const pitcherResultTextColor = computed(() => getContrastingTextColor(pitcherTeamColors.value.primary));
 const batterResultTextColor = computed(() => getContrastingTextColor(batterTeamColors.value.primary));
 


### PR DESCRIPTION
The pitcher and batter team colors were incorrectly displayed during the transition between half-innings. This was because the `pitcherTeamColors` and `batterTeamColors` computed properties were based on `gameStore.gameState.isTopInning`, which updated before the UI reflected the new inning.

This change introduces a new computed property, `isDisplayTopInning`, which correctly reflects the inning state for display purposes, even during the "between innings" phase. The color-related computed properties now use this new property, ensuring that team colors remain synchronized with the players shown on screen.