### PR TITLE
fix(frontend): Prevent TypeError in GameView on unmount

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -369,6 +369,11 @@ const opponentReadyForNext = computed(() => {
 });
 
 const atBatToDisplay = computed(() => {
+    if (!gameStore.gameState) {
+      // During component teardown or initial load, gameState can be null.
+      // Return a default, safe structure to prevent cascading errors.
+      return { batterAction: null, pitcherAction: null, pitchRollResult: null, swingRollResult: null };
+    }
     if (!amIReadyForNext.value && (gameStore.gameState.awayPlayerReadyForNext || gameStore.gameState.homePlayerReadyForNext)) {
         return gameStore.gameState.lastCompletedAtBat;
     }


### PR DESCRIPTION
A TypeError would occur in GameView.vue when the component was unmounted. This was caused by the `atBatToDisplay` computed property attempting to access `gameStore.gameState` after it had already been reset to `null` by the `onUnmounted` lifecycle hook.

This change adds a defensive guard clause to the `atBatToDisplay` computed property. It now checks if `gameStore.gameState` is null and, if so, returns a default, safe object structure. This prevents the null-reference error during component teardown and makes the component more robust.