### PR TITLE
feat: Overhaul DevTools to apply game outcomes

### DIFF
--- a/apps/backend/routes/dev.js
+++ b/apps/backend/routes/dev.js
@@ -2,6 +2,94 @@ const express = require('express');
 const router = express.Router();
 const { pool, io } = require('../server');
 const authenticateToken = require('../middleware/authenticateToken');
+const { applyOutcome } = require('../gameLogic');
+
+// This helper is duplicated from server.js for use in this dev-only route
+async function getActivePlayers(gameId, currentState, client) {
+    try {
+        const participantsResult = await client.query('SELECT * FROM game_participants WHERE game_id = $1', [gameId]);
+        const game = await client.query('SELECT home_team_user_id FROM games WHERE game_id = $1', [gameId]);
+
+        const homeParticipant = participantsResult.rows.find(p => p.user_id === game.rows[0].home_team_user_id);
+        const awayParticipant = participantsResult.rows.find(p => p.user_id !== game.rows[0].home_team_user_id);
+
+        const offensiveParticipant = currentState.isTopInning ? awayParticipant : homeParticipant;
+        const defensiveParticipant = currentState.isTopInning ? homeParticipant : awayParticipant;
+
+        if (!offensiveParticipant?.lineup || !defensiveParticipant?.lineup) {
+          return { batter: null, pitcher: null, offensiveTeam: {}, defensiveTeam: {} };
+        }
+
+        const offensiveTeamState = currentState.isTopInning ? currentState.awayTeam : currentState.homeTeam;
+
+        const batterInfo = offensiveParticipant.lineup.battingOrder[offensiveTeamState.battingOrderPosition];
+        const pitcherCardId = defensiveParticipant.lineup.startingPitcher;
+
+        const batterQuery = await client.query('SELECT * FROM cards_player WHERE card_id = $1', [batterInfo.card_id]);
+        const pitcherQuery = await client.query('SELECT * FROM cards_player WHERE card_id = $1', [pitcherCardId]);
+
+        return {
+            batter: batterQuery.rows[0],
+            pitcher: pitcherQuery.rows[0],
+            offensiveTeam: offensiveParticipant,
+            defensiveTeam: defensiveParticipant,
+        };
+    } catch (error) {
+        console.error('--- CRITICAL ERROR inside getActivePlayers (dev route) ---', error);
+        throw error;
+    }
+}
+
+router.post('/games/:gameId/apply-outcome', authenticateToken, async (req, res) => {
+    const { gameId } = req.params;
+    const { outcome } = req.body;
+    const client = await pool.connect();
+
+    try {
+        await client.query('BEGIN');
+        const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
+
+        if (stateResult.rows.length === 0) {
+            return res.status(404).json({ message: 'Game state not found.' });
+        }
+
+        const currentState = stateResult.rows[0].state_data;
+        const currentTurn = stateResult.rows[0].turn_number;
+
+        const { batter, pitcher, offensiveTeam } = await getActivePlayers(gameId, currentState, client);
+
+        if (!batter || !pitcher) {
+            return res.status(400).json({ message: 'Could not determine active batter or pitcher. Is the lineup set?' });
+        }
+
+        const { newState, events } = applyOutcome(currentState, outcome, batter, pitcher);
+        newState.inningChanged = false; // Prevent complex event generation for this dev tool
+
+        await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
+
+        if (events && events.length > 0) {
+            const combinedLogMessage = `[DEV] ${events.join(' ')}`;
+            await client.query(`INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`, [gameId, req.user.userId, currentTurn + 1, 'dev_event', combinedLogMessage]);
+        }
+
+        if (newState.gameOver) {
+            await client.query(`UPDATE games SET status = 'completed', completed_at = NOW() WHERE game_id = $1`, [gameId]);
+        } else {
+            await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [offensiveTeam.user_id, gameId]);
+        }
+
+        await client.query('COMMIT');
+        io.to(gameId).emit('game-updated');
+        res.status(200).json({ message: 'Outcome applied successfully.' });
+
+    } catch (error) {
+        await client.query('ROLLBACK');
+        console.error('Error applying dev outcome:', error);
+        res.status(500).json({ message: 'Server error while applying outcome.' });
+    } finally {
+        client.release();
+    }
+});
 
 router.post('/games/:gameId/set-state', authenticateToken, async (req, res) => {
     const { gameId } = req.params;

--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -83,6 +83,24 @@ async function setGameState(gameId, partialState) {
   }
 }
 
+async function applyDevOutcome(gameId, outcome) {
+  const auth = useAuthStore();
+  if (!auth.token) return;
+  try {
+    await fetch(`${auth.API_URL}/api/dev/games/${gameId}/apply-outcome`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${auth.token}`
+      },
+      body: JSON.stringify({ outcome })
+    });
+    // The game-updated event will refresh the UI automatically
+  } catch (error) {
+    console.error("Error applying dev outcome:", error);
+  }
+}
+
 async function resolveDefensiveThrow(gameId, throwTo) {
   const auth = useAuthStore();
   if (!auth.token) return;
@@ -388,6 +406,7 @@ async function resetRolls(gameId) {
     displayOuts, setDisplayOuts, isOutcomeHidden, setOutcomeHidden, gameEventsToDisplay,
     submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls,
     updateGameData,
-    resetGameState
+    resetGameState,
+    applyDevOutcome
   };
 })

--- a/apps/frontend/src/views/DevToolView.vue
+++ b/apps/frontend/src/views/DevToolView.vue
@@ -6,127 +6,47 @@ import { useGameStore } from '@/stores/game';
 const gameStore = useGameStore();
 const route = useRoute();
 const gameId = route.params.id;
-const awayBOP = ref(1); // Batting order is 1-indexed for the UI
-const homeBOP = ref(1);
 
-// Form state
-const inning = ref(1);
-const isTopInning = ref(true);
-const outs = ref(0);
-const homeScore = ref(0);
-const awayScore = ref(0);
-const runnerOnFirst = ref(null);
-const runnerOnSecond = ref(null);
-const runnerOnThird = ref(null);
+// New simplified state for the dev tool
+const outcome = ref('SINGLE'); // Default to a common outcome
 
-const homeRoster = computed(() => gameStore.rosters.home || []);
-const awayRoster = computed(() => gameStore.rosters.away || []);
-const allGamePlayers = computed(() => [...homeRoster.value, ...awayRoster.value]);
+const gameState = computed(() => gameStore.gameState);
 
-function handleSubmit() {
-    const partialState = {
-        inning: Number(inning.value),
-        isTopInning: isTopInning.value,
-        outs: Number(outs.value),
-        homeScore: Number(homeScore.value),
-        awayScore: Number(awayScore.value),
-        bases: {
-            first: allGamePlayers.value.find(p => p.card_id === runnerOnFirst.value) || null,
-            second: allGamePlayers.value.find(p => p.card_id === runnerOnSecond.value) || null,
-            third: allGamePlayers.value.find(p => p.card_id === runnerOnThird.value) || null,
-        },
-        // Add these nested objects
-        awayTeam: {
-            battingOrderPosition: Number(awayBOP.value) - 1 // Convert from 1-indexed to 0-indexed
-        },
-        homeTeam: {
-            battingOrderPosition: Number(homeBOP.value) - 1 // Convert from 1-indexed to 0-indexed
-        }
-    };
-    gameStore.setGameState(gameId, partialState);
+// New handler to call the new backend endpoint
+function handleApplyOutcome() {
+    if (!outcome.value) {
+        alert('Please enter an outcome.');
+        return;
+    }
+    // We will add this function to the game store in the next step
+    gameStore.applyDevOutcome(gameId, outcome.value);
 }
 
 onMounted(() => {
-    // Fetch roster data to populate runner dropdowns
+    // Fetch initial game data so we can see the state
     gameStore.fetchGame(gameId); 
 });
 </script>
 
 <template>
     <div class="dev-container">
-        <h1>Game State Debugger</h1>
-        <p>Set a specific game situation to test logic. The game will update in real-time.</p>
+        <h1>Game Logic Debugger</h1>
+        <p>Directly apply a game outcome to test the backend logic. The game will update in real-time.</p>
 
-        <div class="form-grid">
-            <div class="form-group">
-                <label>Inning</label>
-                <input type="number" v-model="inning" min="1" />
-            </div>
-            <div class="form-group">
-                <label>Outs</label>
-                <input type="number" v-model="outs" min="0" max="2" />
-            </div>
-             <div class="form-group">
-                <label>Top/Bottom</label>
-                <select v-model="isTopInning">
-                    <option :value="true">Top</option>
-                    <option :value="false">Bottom</option>
-                </select>
-            </div>
-            <div class="form-group">
-                <label>Away Score</label>
-                <input type="number" v-model="awayScore" min="0" />
-            </div>
-            <div class="form-group">
-                <label>Home Score</label>
-                <input type="number" v-model="homeScore" min="0" />
-            </div>
+        <div class="form-group">
+            <label>Outcome to Apply</label>
+            <input type="text" v-model="outcome" placeholder="e.g., SINGLE, HR, SO, GB" />
         </div>
 
-        <h3>Batting Order</h3>
-        <div class="form-grid">
-            <div class="form-group">
-                <label>Away Team Batter #</label>
-                <input type="number" v-model="awayBOP" min="1" max="9" />
-            </div>
-            <div class="form-group">
-                <label>Home Team Batter #</label>
-                <input type="number" v-model="homeBOP" min="1" max="9" />
-            </div>
-        </div>
+        <button @click="handleApplyOutcome">Apply Outcome</button>
 
-        <h3>Baserunners</h3>
-        <div class="form-grid">
-            <div class="form-group">
-                <label>Runner on 1st</label>
-                <select v-model="runnerOnFirst">
-                    <option :value="null">Empty</option>
-                    <option v-for="player in allGamePlayers" :key="player.card_id" :value="player.card_id">
-                        {{ player.displayName }}
-                    </option>
-                </select>
-            </div>
-             <div class="form-group">
-                <label>Runner on 2nd</label>
-                <select v-model="runnerOnSecond">
-                    <option :value="null">Empty</option>
-                    <option v-for="player in allGamePlayers" :key="player.card_id" :value="player.card_id">
-                        {{ player.displayName }}
-                    </option>
-                </select>
-            </div>
-             <div class="form-group">
-                <label>Runner on 3rd</label>
-                <select v-model="runnerOnThird">
-                    <option :value="null">Empty</option>
-                    <option v-for="player in allGamePlayers" :key="player.card_id" :value="player.card_id">
-                        {{ player.displayName }}
-                    </option>
-                </select>
-            </div>
+        <div class="state-display" v-if="gameState">
+            <h2>Current Game State</h2>
+            <pre>{{ JSON.stringify(gameState, null, 2) }}</pre>
         </div>
-        
-        <button @click="handleSubmit">Set Game State</button>
+        <div v-else>
+            <p>Loading game state...</p>
+        </div>
     </div>
 </template>
 
@@ -136,37 +56,45 @@ onMounted(() => {
         margin: 2rem auto;
         padding: 2rem;
         font-family: sans-serif;
-        background: #fff8e1;
-        border: 2px solid #ffecb3;
+        background: #f0f0f0;
+        border: 2px solid #ccc;
         border-radius: 8px;
     }
-    .form-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 1rem;
-        margin-bottom: 1.5rem;
-    }
     .form-group {
-        display: flex;
-        flex-direction: column;
+        margin-bottom: 1.5rem;
     }
     label {
         font-weight: bold;
         margin-bottom: 0.5rem;
+        display: block;
     }
-    input, select {
+    input {
+        width: 100%;
         padding: 0.5rem;
         border-radius: 4px;
         border: 1px solid #ccc;
+        box-sizing: border-box;
     }
     button {
         width: 100%;
         padding: 1rem;
         font-size: 1.2rem;
-        background-color: #007bff;
+        background-color: #dc3545; /* A more "developery" color */
         color: white;
         border: none;
         border-radius: 4px;
         cursor: pointer;
+        margin-bottom: 1.5rem;
+    }
+    .state-display {
+        background-color: #282c34; /* Dark background for the JSON */
+        color: #abb2bf; /* Light grey text */
+        padding: 1rem;
+        border-radius: 4px;
+        overflow-x: auto; /* Allow horizontal scrolling if needed */
+    }
+    pre {
+        white-space: pre-wrap; /* Wrap long lines */
+        word-wrap: break-word;
     }
 </style>


### PR DESCRIPTION
This commit completely revamps the developer tools to align with modern testing needs.

The previous DevTool, which allowed setting granular game state, has been replaced with a more powerful and streamlined tool. The new tool allows a developer to directly apply a specific game outcome (e.g., 'SINGLE', 'HR', 'SO') to the current game state.

This is accomplished by:
- A new backend endpoint `/api/dev/games/:gameId/apply-outcome` that securely invokes the core `applyOutcome` game logic.
- A simplified `DevToolView.vue` component with a single input for the outcome and a button to apply it.
- A read-only display of the current `gameState` JSON object for immediate verification of the outcome's effects.

This provides a much more effective way to test and debug the backend's game logic by focusing on the consequences of actions rather than manually setting up complex state objects.