### PR TITLE
fix(frontend): Remove extra space in game scorecard

### DIFF
--- a/apps/frontend/src/components/GameScorecard.vue
+++ b/apps/frontend/src/components/GameScorecard.vue
@@ -131,7 +131,6 @@ const statusText = computed(() => {
 
 .game-number {
     font-weight: bold;
-    margin-right: 0.5rem;
 }
 
 .score-inning {


### PR DESCRIPTION
Removes the `margin-right` from the `.game-number` class in `GameScorecard.vue` to eliminate the extra space between the game number and the 'vs.' text.