### PR TITLE
feat: Implement selectable player point sets

### DIFF
--- a/apps/backend/import-points.js
+++ b/apps/backend/import-points.js
@@ -1,0 +1,99 @@
+require('dotenv').config();
+const fs = require('fs');
+const csv = require('csv-parser');
+const { Pool } = require('pg');
+
+// Check for command-line argument for the point set name
+const pointSetName = process.argv[2];
+if (!pointSetName) {
+  console.error('Usage: npm run import:points -- <point_set_name>');
+  console.error('Example: npm run import:points -- season1');
+  process.exit(1);
+}
+
+const dbConfig = {
+  user: process.env.PGUSER,
+  host: process.env.PGHOST,
+  database: process.env.PGDATABASE,
+  password: process.env.PGPASSWORD,
+  port: process.env.PGPORT,
+};
+
+const pool = new Pool(dbConfig);
+
+async function importPoints() {
+  console.log(`Starting points import process for set: "${pointSetName}"...`);
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    console.log(`Creating point set: ${pointSetName}`);
+    await client.query("INSERT INTO point_sets (name) VALUES ($1) ON CONFLICT (name) DO NOTHING", [pointSetName]);
+    const { rows: [{ point_set_id }] } = await client.query("SELECT point_set_id FROM point_sets WHERE name = $1", [pointSetName]);
+
+    const records = [];
+    await new Promise((resolve, reject) => {
+      fs.createReadStream('apps/backend/prices.csv')
+        .pipe(csv())
+        .on('data', (row) => records.push(row))
+        .on('end', resolve)
+        .on('error', reject);
+    });
+
+    let notFoundCount = 0;
+    for (const row of records) {
+      const playerName = row['Team Player'];
+      const team = row['Tm'];
+      const points = row['Upcoming Season'];
+
+      if (!playerName || !team || !points) {
+        console.warn('Skipping row with missing data:', row);
+        continue;
+      }
+
+      const simpleDisplayName = `${playerName} (${team})`;
+      const res = await client.query("SELECT card_id FROM cards_player WHERE display_name = $1", [simpleDisplayName]);
+
+      if (res.rows.length === 1) {
+        // Happy path: unique player found with simple name
+        const card_id = res.rows[0].card_id;
+        await client.query(
+          `INSERT INTO player_point_values (card_id, point_set_id, points) VALUES ($1, $2, $3)
+           ON CONFLICT (card_id, point_set_id) DO UPDATE SET points = $3`,
+          [card_id, point_set_id, points]
+        );
+      } else {
+        // If no simple match, check for ambiguous players to provide a better error message
+        const potentialMatches = await client.query(
+          "SELECT display_name FROM cards_player WHERE name = $1 AND team = $2",
+          [playerName, team]
+        );
+
+        if (potentialMatches.rows.length > 0) {
+          const displayNames = potentialMatches.rows.map(r => `"${r.display_name}"`).join(', ');
+          console.warn(`Ambiguous player: "${simpleDisplayName}". Found possible matches: [${displayNames}]. Please specify the exact card in the source file.`);
+        } else {
+          console.warn(`Player not found: "${simpleDisplayName}"`);
+        }
+        notFoundCount++;
+      }
+    }
+
+    if (notFoundCount > 0) {
+      console.warn(`Warning: ${notFoundCount} players from the CSV were not found or were ambiguous.`);
+    }
+
+    await client.query('COMMIT');
+    console.log('✅ Points import complete!');
+
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('❌ Points import failed:', e);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+importPoints();

--- a/apps/backend/migrations/20250930120000_add_point_system_tables.js
+++ b/apps/backend/migrations/20250930120000_add_point_system_tables.js
@@ -1,0 +1,90 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined;
+
+exports.up = async (pgm) => {
+  // 1. CREATE point_sets TABLE
+  pgm.createTable('point_sets', {
+    point_set_id: 'id',
+    name: { type: 'varchar(100)', notNull: true, unique: true },
+    created_at: {
+      type: 'timestamptz',
+      notNull: true,
+      default: pgm.func('now()'),
+    },
+  });
+
+  // 2. CREATE player_point_values TABLE
+  pgm.createTable('player_point_values', {
+    player_point_value_id: 'id',
+    card_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"cards_player"(card_id)',
+      onDelete: 'CASCADE',
+    },
+    point_set_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"point_sets"(point_set_id)',
+      onDelete: 'CASCADE',
+    },
+    points: { type: 'integer', notNull: true },
+  });
+  pgm.addConstraint('player_point_values', 'player_point_values_pkey', {
+    primaryKey: ['card_id', 'point_set_id'],
+  });
+
+  // 3. ADD display_name to cards_player
+  // The ingestion script will be responsible for populating this value.
+  pgm.addColumns('cards_player', {
+    display_name: { type: 'varchar(255)', unique: true },
+  });
+
+  // --- DATA MIGRATION ---
+
+  // 4. GET the "Original Pts" set ID
+  // We must handle the case where this script is run after the set is created.
+  await pgm.sql("INSERT INTO point_sets (name) VALUES ('Original Pts') ON CONFLICT (name) DO NOTHING;");
+  const { rows: [{ point_set_id }] } = await pgm.db.query("SELECT point_set_id FROM point_sets WHERE name = 'Original Pts'");
+
+  // 5. MIGRATE existing points from `cards_player` to `player_point_values`
+  // This assumes the `ingest-data.js` script has already run and populated the `points` column.
+  await pgm.sql(`
+    INSERT INTO player_point_values (card_id, point_set_id, points)
+    SELECT card_id, ${point_set_id}, points
+    FROM cards_player
+    WHERE points IS NOT NULL
+    ON CONFLICT (card_id, point_set_id) DO NOTHING;
+  `);
+
+  // 6. DROP the old points column from cards_player
+  pgm.dropColumns('cards_player', ['points']);
+};
+
+exports.down = async (pgm) => {
+  // 1. ADD back the points column to cards_player
+  pgm.addColumns('cards_player', {
+    points: { type: 'integer' },
+  });
+
+  // 2. MIGRATE points back from player_point_values to cards_player
+  // This assumes the "Original Pts" set exists.
+  const { rows } = await pgm.db.query("SELECT point_set_id FROM point_sets WHERE name = 'Original Pts'");
+  if (rows.length > 0) {
+    const point_set_id = rows[0].point_set_id;
+    await pgm.sql(`
+      UPDATE cards_player cp
+      SET points = ppv.points
+      FROM player_point_values ppv
+      WHERE cp.card_id = ppv.card_id AND ppv.point_set_id = ${point_set_id};
+    `);
+  }
+
+  // 3. DROP the display_name column
+  pgm.dropColumns('cards_player', ['display_name']);
+
+  // 4. DROP the new tables
+  pgm.dropTable('player_point_values');
+  pgm.dropTable('point_sets');
+};

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -8,7 +8,9 @@
     "start": "node server.js",
     "dev": "node server.js",
     "migrate:create": "node-pg-migrate -r dotenv/config create",
-    "migrate:up": "node-pg-migrate -r dotenv/config up"
+    "migrate:up": "node-pg-migrate -r dotenv/config up",
+    "import:points": "node import-points.js",
+    "update:names": "node update-display-names.js"
   },
   "keywords": [],
   "author": "",

--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -137,12 +137,10 @@ function getOrdinal(n) {
   return n + (s[(v - 20) % 10] || s[v] || s[0]);
 }
 
-function processPlayers(playersToProcess, allPlayers) {
-    const nameCounts = {};
-    allPlayers.forEach(p => { nameCounts[p.name] = (nameCounts[p.name] || 0) + 1; });
+function processPlayers(playersToProcess) {
     playersToProcess.forEach(p => {
         if (!p) return;
-        p.displayName = nameCounts[p.name] > 1 ? `${p.name} (${p.team})` : p.name;
+        // displayName is now pre-calculated and stored in the database as display_name
         if (p.control !== null) {
             p.displayPosition = Number(p.ip) > 3 ? 'SP' : 'RP';
         } else {
@@ -467,8 +465,7 @@ app.post('/api/games/:gameId/lineup', authenticateToken, async (req, res) => {
 
       await client.query(`INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)`, [gameId, 1, initialGameState, false, false]);
       
-      const allCardsResult = await pool.query('SELECT name, team FROM cards_player');
-      processPlayers([pitcher], allCardsResult.rows);
+      processPlayers([pitcher]);
 
       const awayTeam = await client.query('SELECT * FROM teams WHERE user_id = $1', [awayParticipant.user_id]);
       const homeTeam = await client.query('SELECT * FROM teams WHERE user_id = $1', [homeParticipant.user_id]);
@@ -742,14 +739,43 @@ app.get('/api/games', authenticateToken, async (req, res) => {
   }
 });
 
-// GET ALL PLAYER CARDS (now processed)
+// GET ALL POINT SETS
+app.get('/api/point-sets', authenticateToken, async (req, res) => {
+  try {
+    // Order by created_at descending to have the newest sets first
+    const pointSetsResult = await pool.query('SELECT * FROM point_sets ORDER BY created_at DESC');
+    res.json(pointSetsResult.rows);
+  } catch (error) {
+    console.error('Error fetching point sets:', error);
+    res.status(500).json({ message: 'Server error while fetching point sets.' });
+  }
+});
+
+// GET ALL PLAYER CARDS (now with points from a specific set)
 app.get('/api/cards/player', authenticateToken, async (req, res) => {
-    console.log('4. Backend received request for /api/cards/player.');
+    const { point_set_id } = req.query;
+
+    if (!point_set_id) {
+        return res.status(400).json({ message: 'A point_set_id is required.' });
+    }
+
     try {
-        const allCardsResult = await pool.query('SELECT * FROM cards_player ORDER BY name');
-        const processedCards = processPlayers(allCardsResult.rows, allCardsResult.rows);
+        const query = `
+            SELECT
+                cp.*,
+                ppv.points
+            FROM cards_player cp
+            LEFT JOIN player_point_values ppv ON cp.card_id = ppv.card_id
+            WHERE ppv.point_set_id = $1
+            ORDER BY cp.display_name;
+        `;
+        const allCardsResult = await pool.query(query, [point_set_id]);
+        const processedCards = processPlayers(allCardsResult.rows);
         res.json(processedCards);
-    } catch (error) { res.status(500).json({ message: 'Server error fetching player cards.' }); }
+    } catch (error) {
+        console.error('Error fetching player cards with points:', error);
+        res.status(500).json({ message: 'Server error fetching player cards.' });
+    }
 });
 
 // GAME SETUP & PLAY
@@ -991,9 +1017,9 @@ async function getAndProcessGameData(gameId, dbClient) {
       if (p.lineup?.battingOrder) {
         const lineupWithDetails = p.lineup.battingOrder.map(spot => ({ ...spot, player: fullRosterCards.find(c => c.card_id === spot.card_id) }));
         const spCard = fullRosterCards.find(c => c.card_id === p.lineup.startingPitcher);
-        processPlayers(lineupWithDetails.map(l => l.player), allCardsResult.rows);
-        processPlayers(fullRosterCards, allCardsResult.rows);
-        if (spCard) processPlayers([spCard], allCardsResult.rows);
+        processPlayers(lineupWithDetails.map(l => l.player));
+        processPlayers(fullRosterCards);
+        if (spCard) processPlayers([spCard]);
 
         if (p.user_id === game.home_team_user_id) {
           lineups.home = { battingOrder: lineupWithDetails, startingPitcher: spCard };
@@ -1004,8 +1030,8 @@ async function getAndProcessGameData(gameId, dbClient) {
         }
       }
     }
-    if (batter) processPlayers([batter], allCardsResult.rows);
-    if (pitcher) processPlayers([pitcher], allCardsResult.rows);
+    if (batter) processPlayers([batter]);
+    if (pitcher) processPlayers([pitcher]);
   }
 
   return { game, series, gameState: currentState, gameEvents: eventsResult.rows, batter, pitcher, lineups, rosters, teams: teamsData };
@@ -1046,7 +1072,7 @@ app.post('/api/games/:gameId/set-action', authenticateToken, async (req, res) =>
     // If the pitcher has already acted, we resolve the at-bat now.
     if (finalState.currentAtBat.pitcherAction) {
       const { batter, pitcher } = await getActivePlayers(gameId, finalState);
-      processPlayers([batter, pitcher], (await pool.query('SELECT name, team FROM cards_player')).rows);
+      processPlayers([batter, pitcher]);
 
       let outcome = 'OUT';
       let swingRoll = 0;
@@ -1099,7 +1125,7 @@ app.post('/api/games/:gameId/set-action', authenticateToken, async (req, res) =>
           const pitcherCardId = defensiveParticipant.lineup.startingPitcher;
           const pitcherResult = await client.query('SELECT * FROM cards_player WHERE card_id = $1', [pitcherCardId]);
           const pitcher = pitcherResult.rows[0];
-          processPlayers([pitcher], (await pool.query('SELECT name, team FROM cards_player')).rows);
+          processPlayers([pitcher]);
 
           const offensiveTeamResult = await client.query('SELECT logo_url FROM teams WHERE user_id = $1', [offensiveParticipant.user_id]);
           const defensiveTeamResult = await client.query('SELECT abbreviation FROM teams WHERE user_id = $1', [defensiveParticipant.user_id]);
@@ -1155,7 +1181,7 @@ app.post('/api/games/:gameId/pitch', authenticateToken, async (req, res) => {
     const currentTurn = stateResult.rows[0].turn_number;
 
     const { batter, pitcher, offensiveTeam } = await getActivePlayers(gameId, currentState);
-    processPlayers([batter, pitcher], (await pool.query('SELECT name, team FROM cards_player')).rows);
+    processPlayers([batter, pitcher]);
     
     // --- Pitcher Fatigue Logic ---
     if (!currentState.pitcherStats) { currentState.pitcherStats = {}; }
@@ -1254,7 +1280,7 @@ app.post('/api/games/:gameId/pitch', authenticateToken, async (req, res) => {
                 const pitcherCardId = defensiveParticipant.lineup.startingPitcher;
                 const pitcherResult = await client.query('SELECT * FROM cards_player WHERE card_id = $1', [pitcherCardId]);
                 const pitcher = pitcherResult.rows[0];
-                processPlayers([pitcher], (await pool.query('SELECT name, team FROM cards_player')).rows);
+                processPlayers([pitcher]);
 
                 const offensiveTeamResult = await client.query('SELECT logo_url FROM teams WHERE user_id = $1', [offensiveParticipant.user_id]);
                 const defensiveTeamResult = await client.query('SELECT abbreviation FROM teams WHERE user_id = $1', [defensiveParticipant.user_id]);

--- a/apps/backend/update-display-names.js
+++ b/apps/backend/update-display-names.js
@@ -1,0 +1,92 @@
+require('dotenv').config();
+const { Pool } = require('pg');
+
+const dbConfig = {
+  user: process.env.PGUSER,
+  host: process.env.PGHOST,
+  database: process.env.PGDATABASE,
+  password: process.env.PGPASSWORD,
+  port: process.env.PGPORT,
+};
+
+const pool = new Pool(dbConfig);
+
+function formatPositions(fieldingRatings) {
+  if (!fieldingRatings) return 'P';
+  const positions = Object.keys(fieldingRatings);
+  if (positions.length === 0) return 'DH';
+
+  const outfield = new Set();
+  const infield = new Set();
+
+  positions.forEach(pos => {
+    if (['LF', 'CF', 'RF', 'LFRF'].includes(pos)) {
+      outfield.add('OF');
+    } else {
+      infield.add(pos);
+    }
+  });
+
+  const allPos = [...infield, ...outfield];
+  return allPos.sort().join('/');
+}
+
+async function updateDisplayNames() {
+  console.log('Starting display name update process...');
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // 1. Fetch all player cards, including IP for pitchers
+    const { rows: allPlayers } = await client.query('SELECT card_id, name, team, ip, control, fielding_ratings FROM cards_player');
+
+    // 2. Identify ambiguous players (multiple cards for the same team)
+    const playerTeamCounts = {};
+    allPlayers.forEach(player => {
+      const key = `${player.name}|${player.team}`;
+      playerTeamCounts[key] = (playerTeamCounts[key] || 0) + 1;
+    });
+
+    // 3. Iterate and update each player
+    for (const player of allPlayers) {
+      const name = player.name;
+      const team = player.team;
+      const nameTeamKey = `${name}|${team}`;
+      const isPitcher = player.control !== null;
+
+      let newDisplayName;
+      if (playerTeamCounts[nameTeamKey] > 1) {
+        if (isPitcher) {
+          // For ambiguous pitchers, use their role (SP/RP)
+          const role = player.ip > 3 ? 'SP' : 'RP';
+          newDisplayName = `${name} (${role})`;
+        } else {
+          // For ambiguous position players, use their positions
+          const posString = formatPositions(player.fielding_ratings);
+          newDisplayName = `${name} (${posString})`;
+        }
+      } else {
+        newDisplayName = `${name} (${team})`;
+      }
+
+      // 4. Execute the update
+      await client.query(
+        'UPDATE cards_player SET display_name = $1 WHERE card_id = $2',
+        [newDisplayName, player.card_id]
+      );
+    }
+
+    await client.query('COMMIT');
+    console.log('✅ Display names updated successfully for all player cards!');
+
+  } catch (e) {
+    await client.query('ROLLBACK');
+    console.error('❌ Display name update failed:', e);
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+updateDisplayNames();


### PR DESCRIPTION
This commit introduces a new feature allowing users to switch between different sets of player point values in the Roster Builder. It also refactors the player `display_name` to be position-based for ambiguous players.

Key changes include:

- **Database:**
  - Added `point_sets` and `player_point_values` tables to support multiple point systems.
  - Added a unique `display_name` to the `cards_player` table to reliably identify players.
  - Created a migration to apply these schema changes and migrate existing points.

- **Backend:**
  - Updated the `ingest-data.js` script to generate a unique, position-based `display_name` for each player, including SP/RP roles for ambiguous pitchers.
  - Created a safe, one-time `update-display-names.js` script to update existing data without a database wipe.
  - Created a new `import-points.js` script to import new point sets from a CSV file.
  - Added a `/api/point-sets` endpoint to fetch all available point sets.
  - Modified the `/api/cards/player` endpoint to return players with points corresponding to a selected point set.

- **Frontend:**
  - Updated the `auth.js` Pinia store to manage the state for point sets.
  - Added a dropdown menu to the `RosterBuilderView.vue` component, allowing users to select a point set.
  - Implemented logic to dynamically update the player list and roster points when a new point set is selected, without clearing the user's roster.