### PR TITLE
fix(backend): Correct migration to prevent multiple primary keys

### DIFF
--- a/apps/backend/migrations/20250930120000_add_point_system_tables.js
+++ b/apps/backend/migrations/20250930120000_add_point_system_tables.js
@@ -14,25 +14,30 @@ exports.up = async (pgm) => {
     },
   });
 
-  pgm.createTable('player_point_values', {
-    player_point_value_id: 'id',
-    card_id: {
-      type: 'integer',
-      notNull: true,
-      references: '"cards_player"(card_id)',
-      onDelete: 'CASCADE',
+  pgm.createTable(
+    'player_point_values',
+    {
+      player_point_value_id: { type: 'serial' },
+      card_id: {
+        type: 'integer',
+        notNull: true,
+        references: '"cards_player"(card_id)',
+        onDelete: 'CASCADE',
+      },
+      point_set_id: {
+        type: 'integer',
+        notNull: true,
+        references: '"point_sets"(point_set_id)',
+        onDelete: 'CASCADE',
+      },
+      points: { type: 'integer', notNull: true },
     },
-    point_set_id: {
-      type: 'integer',
-      notNull: true,
-      references: '"point_sets"(point_set_id)',
-      onDelete: 'CASCADE',
-    },
-    points: { type: 'integer', notNull: true },
-  });
-  pgm.addConstraint('player_point_values', 'player_point_values_pkey', {
-    primaryKey: ['card_id', 'point_set_id'],
-  });
+    {
+      constraints: {
+        primaryKey: ['card_id', 'point_set_id'],
+      },
+    }
+  );
 
   pgm.addColumns('cards_player', {
     display_name: { type: 'varchar(255)', unique: true },


### PR DESCRIPTION
Refactors the 'add_point_system_tables' migration to define the composite primary key idiomatically within the `createTable` call. This resolves the "multiple primary keys for table 'player_point_values' are not allowed" error by changing the primary key column type from 'id' to 'serial' and using the 'constraints' option.