### PR TITLE
fix(backend): remove one-time script from build process

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,8 +9,7 @@
     "dev": "node server.js",
     "migrate:create": "node-pg-migrate -r dotenv/config create",
     "migrate:up": "node-pg-migrate -r dotenv/config up",
-    "import:points": "node import-points.js",
-    "update:names": "node update-display-names.js"
+    "import:points": "node import-points.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
Removes the `update:names` script from the `package.json` to prevent it from running during the Render build process. This script was causing a database connection error because it's a one-time data migration and shouldn't be part of the regular build cycle.