### PR TITLE
fix(backend): Add missing update:names script

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -9,7 +9,8 @@
     "dev": "node server.js",
     "migrate:create": "node-pg-migrate -r dotenv/config create",
     "migrate:up": "node-pg-migrate -r dotenv/config up",
-    "import:points": "node import-points.js"
+    "import:points": "node import-points.js",
+    "update:names": "node update-display-names.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The Render build was failing because the `update:names` script was being called in the build command but was not defined in `apps/backend/package.json`.

This change adds the missing script to resolve the build error.