### PR TITLE
build: Disable one-time script in build process

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -10,7 +10,7 @@
     "migrate:create": "node-pg-migrate -r dotenv/config create",
     "migrate:up": "node-pg-migrate -r dotenv/config up",
     "import:points": "node import-points.js",
-    "update:names": "node update-display-names.js"
+    "update:names": "echo 'This script is not intended to be run as part of the build process.'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The `update:names` script, which runs `update-display-names.js`, was causing the build to fail in the Render environment. This script requires a database connection that is not available during the stateless build phase, resulting in an `ECONNREFUSED` error.

This change modifies the `update:names` script in `apps/backend/package.json` to a simple `echo` command. This effectively disables the script from running during deployment, resolving the build failure. One-time data migration scripts should be run manually or as separate post-deploy jobs, not as part of the application build.