### PR TITLE
fix(backend): Refine display_name script for production

### DIFF
--- a/apps/backend/gameLogic.js
+++ b/apps/backend/gameLogic.js
@@ -69,7 +69,7 @@ function applyOutcome(state, outcome, batter, pitcher, infieldDefense = 0) {
   else if (outcome.includes('GB')) {
     if (state.infieldIn && newState.outs < 2 && newState.bases.third) {
         events.push(`${batter.displayName} hits a ground ball with the infield in...`);
-        newState.currentPlay = { type: 'INFIELD_IN_PLAY', payload: { runner: newState.bases.third, batter: runnerData } };
+        newState.currentPlay = { type: 'INFIELD_IN', runner: newState.bases.third, batter: runnerData };
     }
     else if (newState.outs <= 1 && newState.bases.first) {
         const dpRoll = Math.floor(Math.random() * 20) + 1;
@@ -101,16 +101,11 @@ function applyOutcome(state, outcome, batter, pitcher, infieldDefense = 0) {
     newState.outs++;
     if (newState.outs < 3 && (newState.bases.first || newState.bases.second || newState.bases.third)) {
         events.push(`${batter.displayName} flies out.`);
-        newState.currentPlay = {
-            type: 'TAG_UP',
-            payload: {
-                decisions: [
-                    { runner: state.bases.third, from: 3 },
-                    { runner: state.bases.second, from: 2 },
-                    { runner: state.bases.first, from: 1 },
-                ].filter(d => d.runner)
-            }
-        };
+        newState.currentPlay = { hitType: 'FB', decisions: [
+            { runner: state.bases.third, from: 3 },
+            { runner: state.bases.second, from: 2 },
+            { runner: state.bases.first, from: 1 },
+        ].filter(d => d.runner) };
     } else {
         events.push(`${batter.displayName} flies out.`);
     }
@@ -130,7 +125,7 @@ function applyOutcome(state, outcome, batter, pitcher, infieldDefense = 0) {
           newState.bases.first = null;
           events.push(`${batter.displayName} steals second base!`);
       } else if (decisions.length > 0) {
-          newState.currentPlay = { type: 'ADVANCE', payload: { decisions: decisions, hitType: '1B' } };
+          newState.currentPlay = { hitType: '1B', decisions: decisions };
       }
   }
   else if (outcome === '2B') {
@@ -140,7 +135,7 @@ function applyOutcome(state, outcome, batter, pitcher, infieldDefense = 0) {
       if (newState.bases.first) { newState.bases.third = newState.bases.first; newState.bases.first = null; }
       newState.bases.second = runnerData;
       if (runnerFromThird) {
-        newState.currentPlay = { type: 'ADVANCE', payload: { decisions: [{ runner: runnerFromThird, from: 3 }], hitType: '2B' } };
+        newState.currentPlay = { hitType: '2B', decisions: [{ runner: runnerFromThird, from: 3 }] };
       }
   }
   else if (outcome === 'IBB') {

--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -152,83 +152,6 @@ function processPlayers(playersToProcess) {
 };
 
 
-async function initializePitcherFatigue(gameId, client) {
-    const gameResult = await client.query('SELECT series_id, game_in_series FROM games WHERE game_id = $1', [gameId]);
-    const { series_id, game_in_series } = gameResult.rows[0];
-
-    if (!series_id || game_in_series < 2) {
-        return {}; // Not a series or game 1, no fatigue to carry over.
-    }
-
-    const finalPitcherStats = {};
-
-    const participants = await client.query('SELECT user_id, roster_id FROM game_participants WHERE game_id = $1', [gameId]);
-
-    for (const participant of participants.rows) {
-        const rosterCardsResult = await client.query(
-            `SELECT cp.* FROM cards_player cp JOIN roster_cards rc ON cp.card_id = rc.card_id WHERE rc.roster_id = $1 AND cp.ip IS NOT NULL AND cp.ip <= 3`,
-            [participant.roster_id]
-        );
-        const relievers = rosterCardsResult.rows;
-
-        const prevGameNumber = game_in_series - 1;
-        const prevTwoGameNumber = game_in_series - 2;
-
-        const prevGameResult = await client.query('SELECT game_id FROM games WHERE series_id = $1 AND game_in_series = $2', [series_id, prevGameNumber]);
-        if (prevGameResult.rows.length === 0) continue;
-        const prevGameId = prevGameResult.rows[0].game_id;
-
-        let prevTwoGameId = null;
-        if (prevTwoGameNumber > 0) {
-            const prevTwoGameResult = await client.query('SELECT game_id FROM games WHERE series_id = $1 AND game_in_series = $2', [series_id, prevTwoGameNumber]);
-            if (prevTwoGameResult.rows.length > 0) {
-                prevTwoGameId = prevTwoGameResult.rows[0].game_id;
-            }
-        }
-
-        const prevGameStatesResult = await client.query('SELECT state_data FROM game_states WHERE game_id = $1', [prevGameId]);
-        const prevGameStates = prevGameStatesResult.rows.map(r => r.state_data);
-
-        let prevTwoGameStates = [];
-        if (prevTwoGameId) {
-             const prevTwoGameStatesResult = await client.query('SELECT state_data FROM game_states WHERE game_id = $1', [prevTwoGameId]);
-             prevTwoGameStates = prevTwoGameStatesResult.rows.map(r => r.state_data);
-        }
-
-        for (const reliever of relievers) {
-            let isTired = false;
-
-            if (prevTwoGameId) {
-                const pitchedInPrevGame = prevGameStates.some(state => state.pitcherStats && state.pitcherStats[reliever.card_id]);
-                const pitchedInPrevTwoGame = prevTwoGameStates.some(state => state.pitcherStats && state.pitcherStats[reliever.card_id]);
-                if (pitchedInPrevGame && pitchedInPrevTwoGame) {
-                    isTired = true;
-                }
-            }
-
-            if (!isTired) {
-                for (const state of prevGameStates) {
-                    const pitcherInState = state.currentAtBat?.pitcher || state.lastCompletedAtBat?.pitcher;
-                    if (pitcherInState?.card_id === reliever.card_id) {
-                        const stats = state.pitcherStats[reliever.card_id] || { ip: 0, runs: 0 };
-                        const fatigueThreshold = reliever.ip - Math.floor(stats.runs / 3);
-                        if (stats.ip > fatigueThreshold) {
-                            isTired = true;
-                            break;
-                        }
-                    }
-                }
-            }
-
-            if (isTired) {
-                finalPitcherStats[reliever.card_id] = { ip: reliever.ip + 1, runs: 0 };
-            }
-        }
-    }
-
-    return finalPitcherStats;
-}
-
 // --- HELPER: Handles series logic after a game completes ---
 async function handleSeriesProgression(gameId, client) {
     // 1. Get game and series info
@@ -522,9 +445,9 @@ app.post('/api/games/:gameId/lineup', authenticateToken, async (req, res) => {
       const initialGameState = {
         inning: 1, isTopInning: true, awayScore: 0, homeScore: 0, outs: 0,
         bases: { first: null, second: null, third: null },
-        pitcherStats: await initializePitcherFatigue(gameId, client),
-        awayTeam: { userId: awayParticipant.user_id, rosterId: awayParticipant.roster_id, battingOrderPosition: 0, used_player_ids: [] },
-        homeTeam: { userId: homeParticipant.user_id, rosterId: homeParticipant.roster_id, battingOrderPosition: 0, used_player_ids: [] },
+        pitcherStats: {},
+        awayTeam: { userId: awayParticipant.user_id, rosterId: awayParticipant.roster_id, battingOrderPosition: 0 },
+        homeTeam: { userId: homeParticipant.user_id, rosterId: homeParticipant.roster_id, battingOrderPosition: 0 },
         awayPlayerReadyForNext: false,
         homePlayerReadyForNext: false,
         lastCompletedAtBat: null,
@@ -600,6 +523,8 @@ app.get('/api/available-teams', async (req, res) => {
   }
 });
 
+// MAKE A SUBSTITUTION (Protected Route)
+// MAKE A SUBSTITUTION (Protected Route)
 app.post('/api/games/:gameId/substitute', authenticateToken, async (req, res) => {
   const { gameId } = req.params;
   const { playerInId, playerOutId, position } = req.body;
@@ -613,18 +538,10 @@ app.post('/api/games/:gameId/substitute', authenticateToken, async (req, res) =>
     const currentTurn = stateResult.rows[0].turn_number;
 
     let newState = JSON.parse(JSON.stringify(currentState));
-
-    const participantResult = await client.query('SELECT * FROM game_participants WHERE game_id = $1 AND user_id = $2', [gameId, userId]);
-    const participant = participantResult.rows[0];
-    const teamKey = participant.home_or_away === 'home' ? 'homeTeam' : 'awayTeam';
-
-    if (newState[teamKey].used_player_ids.includes(playerInId)) {
-        return res.status(400).json({ message: 'This player has already been in the game and cannot re-enter.' });
-    }
-
     let logMessage = '';
     let playerInCard;
 
+    // --- NEW: Generate Replacement Player if needed ---
     if (playerInId === 'replacement_hitter') {
         playerInCard = { 
             card_id: -1, name: 'Replacement Hitter', on_base: -10, speed: 'B', 
@@ -641,25 +558,21 @@ app.post('/api/games/:gameId/substitute', authenticateToken, async (req, res) =>
         playerInCard = playerInResult.rows[0];
     }
 
-    const playerOutResult = await pool.query('SELECT * FROM cards_player WHERE card_id = $1', [playerOutId]);
-    const playerOutCard = playerOutResult.rows[0];
+    const playerOutCard = await pool.query('SELECT * FROM cards_player WHERE card_id = $1', [playerOutId]);
+    const teamKey = newState.homeTeam.lineup.some(p => p.card_id === playerOutId) ? 'homeTeam' : 'awayTeam';
     
-    newState[teamKey].used_player_ids.push(playerOutId);
-
     if (position === 'P') {
-        newState.currentAtBat.pitcher = playerInCard;
-        logMessage = `${teamKey === 'homeTeam' ? 'Home' : 'Away'} brings in ${playerInCard.name} to relieve ${playerOutCard.name}.`;
+        newState[teamKey].currentPitcherId = playerInCard.card_id;
+        logMessage = `${teamKey === 'homeTeam' ? 'Home' : 'Away'} brings in ${playerInCard.name} to relieve ${playerOutCard.rows[0].name}.`;
     } else {
-        const lineup = participant.lineup.battingOrder;
+        const lineup = newState[teamKey].lineup;
         const spotIndex = lineup.findIndex(spot => spot.card_id === playerOutId);
         if (spotIndex > -1) {
             lineup[spotIndex].card_id = playerInCard.card_id;
-            lineup[spotIndex].position = position; // Update position
-            logMessage = `${teamKey === 'homeTeam' ? 'Home' : 'Away'} substitutes ${playerInCard.name} for ${playerOutCard.name}. ${playerInCard.name} will now play ${position}.`;
+            logMessage = `${teamKey === 'homeTeam' ? 'Home' : 'Away'} substitutes ${playerInCard.name} for ${playerOutCard.rows[0].name}.`;
         }
     }
 
-    await client.query('UPDATE game_participants SET lineup = $1::jsonb WHERE game_id = $2 AND user_id = $3', [JSON.stringify({ battingOrder: participant.lineup.battingOrder, startingPitcher: participant.lineup.startingPitcher }), gameId, userId]);
     await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
     await client.query('INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)', [gameId, userId, currentTurn + 1, 'substitution', logMessage]);
     
@@ -1569,129 +1482,9 @@ app.post('/api/games/:gameId/declare-home', authenticateToken, async (req, res) 
   }
 });
 
-app.post('/api/games/:gameId/initiate-steal', authenticateToken, async (req, res) => {
-  const { gameId } = req.params;
-  const { decisions } = req.body; // e.g., { '1': true, '2': true }
-  const client = await pool.connect();
-  try {
-    await client.query('BEGIN');
-    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
-    let newState = stateResult.rows[0].state_data;
-    const currentTurn = stateResult.rows[0].turn_number;
-    const { defensiveTeam } = await getActivePlayers(gameId, newState);
-
-    newState.currentPlay = {
-      type: 'STEAL_ATTEMPT',
-      payload: { decisions }
-    };
-
-    // Pass the turn to the defensive player to make their throw
-    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.user_id, gameId]);
-    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
-
-    await client.query('COMMIT');
-    const gameData = await getAndProcessGameData(gameId, client);
-    io.to(gameId).emit('game-updated', gameData);
-    res.sendStatus(200);
-
-  } catch (error) {
-    await client.query('ROLLBACK');
-    console.error(`Error initiating steal for game ${gameId}:`, error);
-    res.status(500).json({ message: 'Server error during steal initiation.' });
-  } finally {
-    client.release();
-  }
-});
-
-app.post('/api/games/:gameId/resolve-steal', authenticateToken, async (req, res) => {
-  const { gameId } = req.params;
-  const { throwTo } = req.body; // e.g., 2 for second base, 3 for third base
-  const userId = req.user.userId;
-  const client = await pool.connect();
-
-  try {
-    await client.query('BEGIN');
-    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
-    let newState = stateResult.rows[0].state_data;
-    const currentTurn = stateResult.rows[0].turn_number;
-    const { offensiveTeam, defensiveTeam } = await getActivePlayers(gameId, newState);
-
-    const { decisions } = newState.currentPlay.payload;
-    const events = [];
-    const baseMap = { 1: 'first', 2: 'second', 3: 'third' };
-
-    // 1. Handle automatic advances for any runner not being thrown at
-    for (const fromBaseStr in decisions) {
-      if (decisions[fromBaseStr]) {
-        const fromBase = parseInt(fromBaseStr, 10);
-        const toBase = fromBase + 1;
-        if (toBase !== throwTo) {
-          const runner = newState.bases[baseMap[fromBase]];
-          if (runner) {
-            newState.bases[baseMap[toBase]] = runner;
-            newState.bases[baseMap[fromBase]] = null;
-            events.push(`${runner.name} steals ${getOrdinal(toBase)} base uncontested.`);
-          }
-        }
-      }
-    }
-
-    // 2. Resolve the contested throw
-    const fromBaseOfThrow = throwTo - 1;
-    const runner = newState.bases[baseMap[fromBaseOfThrow]];
-    if (runner) {
-      const catcherInfo = defensiveTeam.lineup.battingOrder.find(p => p.position === 'C');
-      const catcherCard = await pool.query('SELECT fielding_ratings FROM cards_player WHERE card_id = $1', [catcherInfo.card_id]);
-      const catcherArm = catcherCard.rows[0].fielding_ratings['C'] || 0;
-      const d20Roll = Math.floor(Math.random() * 20) + 1;
-      const defenseTotal = catcherArm + d20Roll;
-
-      if (runner.speed > defenseTotal) { // SAFE
-        newState.bases[baseMap[throwTo]] = runner;
-        newState.bases[baseMap[fromBaseOfThrow]] = null;
-        events.push(`${runner.name} is SAFE at ${getOrdinal(throwTo)}! (Speed ${runner.speed} vs. Throw ${defenseTotal})`);
-      } else { // OUT
-        newState.outs++;
-        newState.bases[baseMap[fromBaseOfThrow]] = null;
-        events.push(`${runner.name} is THROWN OUT at ${getOrdinal(throwTo)}! (Speed ${runner.speed} vs. Throw ${defenseTotal})`);
-      }
-    }
-
-    // 3. Finalize the turn state
-    newState.currentPlay = null;
-
-    if (newState.outs >= 3) {
-        // Inning change logic
-        const wasTop = newState.isTopInning;
-        newState.isTopInning = !newState.isTopInning;
-        if (newState.isTopInning) newState.inning++;
-        newState.outs = 0;
-        newState.bases = { first: null, second: null, third: null };
-        // Inning change event will be created by the client or a subsequent state change
-    }
-
-    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
-    for (const logMessage of events) {
-        await client.query(`INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`, [gameId, userId, currentTurn + 1, 'steal', logMessage]);
-    }
-
-    // Turn goes back to the offensive player to continue the at-bat
-    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [offensiveTeam.user_id, gameId]);
-    await client.query('COMMIT');
-
-    const gameData = await getAndProcessGameData(gameId, client);
-    io.to(gameId).emit('game-updated', gameData);
-    res.sendStatus(200);
-
-  } catch (error) {
-    await client.query('ROLLBACK');
-    console.error(`Error resolving steal for game ${gameId}:`, error);
-    res.status(500).json({ message: 'Server error during steal resolution.' });
-  } finally {
-    client.release();
-  }
-});
-
+// OFFENSE declares which runners to send
+// in server.js
+// in server.js
 app.post('/api/games/:gameId/submit-decisions', authenticateToken, async (req, res) => {
     const { gameId } = req.params;
     const { decisions } = req.body;
@@ -1699,28 +1492,32 @@ app.post('/api/games/:gameId/submit-decisions', authenticateToken, async (req, r
     try {
         await client.query('BEGIN');
         const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
-        let newState = JSON.parse(JSON.stringify(stateResult.rows[0].state_data));
+        let newState = stateResult.rows[0].state_data;
         const currentTurn = stateResult.rows[0].turn_number;
-        const { offensiveTeam, defensiveTeam } = await getActivePlayers(gameId, newState);
+        const { defensiveTeam } = await getActivePlayers(gameId, newState);
 
         const runnersWereSent = Object.values(decisions).some(sent => sent);
 
         if (runnersWereSent) {
-            newState.currentPlay.payload.choices = decisions;
+            // If runners were sent, proceed to the defensive decision
+            newState.currentPlay.choices = decisions;
             await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.user_id, gameId]);
         } else {
-            newState.currentPlay = null;
+            // If no runners were sent, the play is over. Finalize the turn.
             const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
             newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
-            await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [offensiveTeam.user_id, gameId]);
+            await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.user_id, gameId]);
         }
         
+        // Clear the decision-making part of the play
+        newState.currentPlay.decisions = [];
         await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
-        await client.query('COMMIT');
 
+        await client.query('COMMIT');
         const gameData = await getAndProcessGameData(gameId, client);
         io.to(gameId).emit('game-updated', gameData);
         res.sendStatus(200);
+
     } catch (error) {
         await client.query('ROLLBACK');
         console.error(`Error submitting decisions for game ${gameId}:`, error);
@@ -1730,6 +1527,7 @@ app.post('/api/games/:gameId/submit-decisions', authenticateToken, async (req, r
     }
 });
 
+// in server.js
 app.post('/api/games/:gameId/resolve-throw', authenticateToken, async (req, res) => {
     const { gameId } = req.params;
     const { throwTo } = req.body;
@@ -1738,87 +1536,88 @@ app.post('/api/games/:gameId/resolve-throw', authenticateToken, async (req, res)
     try {
         await client.query('BEGIN');
         const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
-        let newState = JSON.parse(JSON.stringify(stateResult.rows[0].state_data));
+        let newState = stateResult.rows[0].state_data;
         const currentTurn = stateResult.rows[0].turn_number;
-        
-        const { offensiveTeam, defensiveTeam } = await getActivePlayers(gameId, newState);
-        const outfieldDefense = await getOutfieldDefense(defensiveTeam);
-
-        const { type, payload } = newState.currentPlay;
-        const { choices } = payload;
+        const { defensiveTeam } = await getActivePlayers(gameId, newState);
         const events = [];
-        const baseMap = { 1: 'first', 2: 'second', 3: 'third' };
+
+        const isSteal = newState.currentPlay.hitType === 'STEAL';
+        let defenseTotal = 0;
+
+        if (isSteal) {
+            const catcherInfo = defensiveTeam.lineup.battingOrder.find(p => p.position === 'C');
+            const catcherCard = await pool.query('SELECT fielding_ratings FROM cards_player WHERE card_id = $1', [catcherInfo.card_id]);
+            const catcherArm = catcherCard.rows[0].fielding_ratings['C'] || 0;
+            defenseTotal = catcherArm + Math.floor(Math.random() * 20) + 1;
+        } else {
+            const outfieldDefense = await getOutfieldDefense(defensiveTeam);
+            defenseTotal = outfieldDefense + Math.floor(Math.random() * 20) + 1;
+        }
         const scoreKey = newState.isTopInning ? 'awayScore' : 'homeScore';
 
+        const choices = newState.currentPlay.choices;
+        const baseMap = { 1: 'first', 2: 'second', 3: 'third' };
+
+        // 1. Resolve all "unchallenged" advances first
         for (const fromBaseStr in choices) {
-            if (choices[fromBaseStr]) {
+            if (choices[fromBaseStr] && parseInt(fromBaseStr, 10) !== throwTo - 1) {
                 const fromBase = parseInt(fromBaseStr, 10);
-                const toBase = fromBase + 1;
                 const runner = newState.bases[baseMap[fromBase]];
-
-                if (runner && toBase !== throwTo) {
-                    if (toBase === 4) {
-                        newState[scoreKey]++;
-                        events.push(`${runner.name} scores!`);
-                    } else {
-                        newState.bases[baseMap[toBase]] = runner;
-                        events.push(`${runner.name} advances to ${getOrdinal(toBase)}.`);
-                    }
-                    newState.bases[baseMap[fromBase]] = null;
+                if(runner) {
+                    if (fromBase === 3) { newState[scoreKey]++; newState.bases.third = null; }
+                    if (fromBase === 2) { newState.bases.third = runner; newState.bases.second = null; }
+                    if (fromBase === 1) { newState.bases.second = runner; newState.bases.first = null; }
+                    events.push(`${runner.runner.name} advances safely.`);
                 }
             }
         }
 
-        const fromBaseOfThrow = throwTo - 1;
-        const runnerToChallenge = newState.bases[baseMap[fromBaseOfThrow]];
-        if (runnerToChallenge) {
-            const d20Roll = Math.floor(Math.random() * 20) + 1;
-            let speed = runnerToChallenge.speed;
-            let defenseRoll = outfieldDefense + d20Roll;
+        // 2. Resolve the "challenged" throw
+        const challengedBase = throwTo - 1;
+        const runner = newState.bases[baseMap[challengedBase]];
+        if (runner) {
+            const throwRoll = Math.floor(Math.random() * 20) + 1;
+            let speed = runner.runner.speed;
+            if (challengedBase === 3) speed += 5; // Going home
+            if (challengedBase === 1) speed -= 5; // Tagging to 2nd
 
-            if (type === 'ADVANCE') {
-                if (throwTo === 4) speed += 5;
-                if (newState.outs === 2) speed += 5;
-            } else if (type === 'TAG_UP') {
-                if (throwTo === 4) speed += 5;
-                if (throwTo === 2) speed -= 5;
-            }
+            const defenseTotal = outfieldDefense + throwRoll;
 
-            const isSafe = type === 'ADVANCE' ? speed >= defenseRoll : speed > defenseRoll;
-
-            if (isSafe) {
-                if (throwTo === 4) {
-                    newState[scoreKey]++;
-                    events.push(`${runnerToChallenge.name} is SAFE at home!`);
-                } else {
-                    newState.bases[baseMap[throwTo]] = runnerToChallenge;
-                    events.push(`${runnerToChallenge.name} is SAFE at ${getOrdinal(throwTo)}!`);
-                }
-                newState.bases[baseMap[fromBaseOfThrow]] = null;
-            } else {
+            if (speed > defenseTotal) { // SAFE
+                if (challengedBase === 3) { newState[scoreKey]++; newState.bases.third = null; }
+                if (challengedBase === 2) { newState.bases.third = runner; newState.bases.second = null; }
+                if (challengedBase === 1) { newState.bases.second = runner; newState.bases.first = null; }
+                events.push(`${runner.runner.name} is SAFE at ${throwTo}B!`);
+            } else { // OUT
                 newState.outs++;
-                newState.bases[baseMap[fromBaseOfThrow]] = null;
-                events.push(`${runnerToChallenge.name} is THROWN OUT at ${getOrdinal(throwTo)}!`);
+                newState.bases[baseMap[challengedBase]] = null;
+                events.push(`${runner.runner.name} is THROWN OUT at ${throwTo}B!`);
             }
         }
 
+        // 3. Finalize the turn state
         newState.currentPlay = null;
-        const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
-        newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
+        // On a steal, the batter does NOT advance. On other plays, they do.
+        if (!isSteal) {
+            const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
+            newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
+        }
 
         if (newState.outs >= 3) {
-            newState.isTopInning = !newState.isTopInning;
-            if (newState.isTopInning) newState.inning++;
-            newState.outs = 0;
-            newState.bases = { first: null, second: null, third: null };
+          newState.isTopInning = !newState.isTopInning;
+      if (newState.isTopInning) newState.inning++;
+      newState.outs = 0;
+      newState.bases = { first: null, second: null, third: null };
         }
 
         await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
         for (const logMessage of events) {
             await client.query(`INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`, [gameId, userId, currentTurn + 1, 'baserunning', logMessage]);
         }
+        // On a steal, turn goes back to the pitcher.
+        const pitcherId = defensiveTeam.userId;
         
-        await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [offensiveTeam.user_id, gameId]);
+        await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.userId, gameId]);
         await client.query('COMMIT');
         
         const gameData = await getAndProcessGameData(gameId, client);
@@ -1834,75 +1633,370 @@ app.post('/api/games/:gameId/resolve-throw', authenticateToken, async (req, res)
     }
 });
 
-app.post('/api/games/:gameId/resolve-infield-in-play', authenticateToken, async (req, res) => {
-    const { gameId } = req.params;
-    const { sendRunner } = req.body;
-    const userId = req.user.userId;
-    const client = await pool.connect();
-    try {
-        await client.query('BEGIN');
-        const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
-        let newState = JSON.parse(JSON.stringify(stateResult.rows[0].state_data));
-        const currentTurn = stateResult.rows[0].turn_number;
+// in server.js
+app.post('/api/games/:gameId/infield-in-play', authenticateToken, async (req, res) => {
+  const { gameId } = req.params;
+  const { sendRunner } = req.body; // boolean
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
+    let currentState = stateResult.rows[0].state_data;
+    const currentTurn = stateResult.rows[0].turn_number;
+    const { defensiveTeam } = await getActivePlayers(gameId, currentState);
+    const infieldDefense = await getInfieldDefense(defensiveTeam);
 
-        const { offensiveTeam, defensiveTeam } = await getActivePlayers(gameId, newState);
-        const infieldDefense = await getInfieldDefense(defensiveTeam);
+    const events = [];
+    let newState = JSON.parse(JSON.stringify(currentState));
+    const runner = newState.infieldInDecision.runner;
+    const batter = newState.infieldInDecision.batter;
+    const scoreKey = newState.isTopInning ? 'awayScore' : 'homeScore';
 
-        const { runner, batter } = newState.currentPlay.payload;
-        const events = [];
-        const scoreKey = newState.isTopInning ? 'awayScore' : 'homeScore';
-
-        if (sendRunner) {
-            const d20Roll = Math.floor(Math.random() * 20) + 1;
-            const defenseTotal = infieldDefense + d20Roll;
-            if (runner.speed > defenseTotal) {
-                newState[scoreKey]++;
-                newState.bases.third = null;
-                newState.bases.first = batter;
-                events.push(`${runner.name} is SENT HOME... and scores! Batter reaches on a fielder's choice.`);
-            } else {
-                newState.outs++;
-                newState.bases.third = null;
-                newState.bases.first = batter;
-                events.push(`${runner.name} is THROWN OUT at the plate! Batter reaches on a fielder's choice.`);
-            }
-        } else {
-            newState.outs++;
-            events.push(`The runner holds at third. ${batter.name} is out at first.`);
-        }
-
-        newState.currentPlay = null;
-        const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
-        newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
-
-        if (newState.outs >= 3) {
-            newState.isTopInning = !newState.isTopInning;
-            if (newState.isTopInning) newState.inning++;
-            newState.outs = 0;
-            newState.bases = { first: null, second: null, third: null };
-        }
-        
-        await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
-        for (const logMessage of events) {
-            await client.query(`INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`, [gameId, userId, currentTurn + 1, 'infield-in', logMessage]);
-        }
-
-        await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [offensiveTeam.user_id, gameId]);
-        await client.query('COMMIT');
-
-        const gameData = await getAndProcessGameData(gameId, client);
-        io.to(gameId).emit('game-updated', gameData);
-        res.sendStatus(200);
-
-    } catch (error) {
-        await client.query('ROLLBACK');
-        console.error(`Error resolving infield-in play for game ${gameId}:`, error);
-        res.status(500).json({ message: 'Server error during infield-in play resolution.' });
-    } finally {
-        client.release();
+    if (sendRunner) {
+      const throwRoll = Math.floor(Math.random() * 20) + 1;
+      const defenseTotal = infieldDefense + throwRoll;
+      if (runner.speed > defenseTotal) {
+        // SAFE at home, batter safe at first
+        events.push(`${runner.name} is SENT HOME... and scores! Batter reaches on a fielder's choice.`);
+        newState[scoreKey]++;
+        newState.bases.third = null;
+        newState.bases.first = batter;
+      } else {
+        // OUT at home, batter safe at first
+        events.push(`${runner.name} is THROWN OUT at the plate! Batter reaches on a fielder's choice.`);
+        newState.outs++;
+        newState.bases.third = null;
+        newState.bases.first = batter;
+      }
+    } else {
+      // HOLD runner
+      events.push(`The runner holds at third. ${batter.name} is out at first.`);
+      newState.outs++;
     }
+
+    newState.infieldInDecision = null;
+    const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
+    newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
+
+    if (newState.outs >= 3) {
+      const wasTop = newState.isTopInning;
+      newState.isTopInning = !newState.isTopInning;
+      if (newState.isTopInning) newState.inning++;
+      newState.outs = 0;
+      newState.bases = { first: null, second: null, third: null };
+      if (newState.inning <= 9 || (newState.inning > 9 && wasTop)) {
+        // This is now handled by the inningChangeEvent logic
+      }
+    }
+
+    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
+    for (const logMessage of events) {
+      // FIX 2: Added the user_id back into the event log query.
+      await client.query(
+        `INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`,
+        [gameId, userId, currentTurn + 1, 'tag-up', logMessage]
+      );
+    }
+    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.userId, gameId]);
+    await client.query('COMMIT');
+
+    const gameData = await getAndProcessGameData(gameId, client);
+    io.to(gameId).emit('game-updated', gameData);
+    res.sendStatus(200);
+  } catch (error) { /* ... */ }
+  finally { client.release(); }
 });
 
+// in server.js
+app.post('/api/games/:gameId/tag-up', authenticateToken, async (req, res) => {
+  const { gameId } = req.params;
+  const { decisions } = req.body;
+  const userId = req.user.userId; // Get the current user's ID
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
+    let currentState = stateResult.rows[0].state_data;
+    const currentTurn = stateResult.rows[0].turn_number;
+
+    const { defensiveTeam } = await getActivePlayers(gameId, currentState);
+    const outfieldDefense = await getOutfieldDefense(defensiveTeam);
+
+    const events = [];
+    let newState = JSON.parse(JSON.stringify(currentState));
+    const scoreKey = newState.isTopInning ? 'awayScore' : 'homeScore'; // Define the score key
+
+    // Resolve each tag-up decision
+    for (const fromBaseStr in decisions) {
+        if (decisions[fromBaseStr]) {
+            const fromBase = parseInt(fromBaseStr, 10);
+            const baseMap = { 3: 'third', 2: 'second', 1: 'first' };
+            const runner = newState.bases[baseMap[fromBase]];
+
+            if (!runner) continue;
+
+            const throwRoll = Math.floor(Math.random() * 20) + 1;
+            let speed = runner.speed;
+
+            if (fromBase === 3) speed += 5;
+            if (fromBase === 1) speed -= 5;
+
+            const defenseTotal = outfieldDefense + throwRoll;
+
+            if (speed > defenseTotal) {
+                // SAFE
+                // FIX 1: Use the dynamic scoreKey to award the run to the correct team.
+                if (fromBase === 3) { newState[scoreKey]++; newState.bases.third = null; }
+                if (fromBase === 2) { newState.bases.third = runner; newState.bases.second = null; }
+                if (fromBase === 1) { newState.bases.second = runner; newState.bases.first = null; }
+                events.push(`${runner.name} tags up and is SAFE!`);
+            } else {
+                // OUT
+                newState.outs++;
+                newState.bases[baseMap[fromBase]] = null;
+                events.push(`${runner.name} is THROWN OUT trying to tag up!`);
+            }
+        }
+    }
+
+    newState.tagUpDecisions = null;
+
+    const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
+    newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
+
+    if (newState.outs >= 3) {
+      const wasTop = newState.isTopInning;
+      newState.isTopInning = !newState.isTopInning;
+      if (newState.isTopInning) newState.inning++;
+      newState.outs = 0;
+      newState.bases = { first: null, second: null, third: null };
+      if (newState.inning <= 9 || (newState.inning > 9 && wasTop)) {
+      }
+    }
+
+    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
+    for (const logMessage of events) {
+      // FIX 2: Added the user_id back into the event log query.
+      await client.query(
+        `INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`,
+        [gameId, userId, currentTurn + 1, 'tag-up', logMessage]
+      );
+    }
+    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.userId, gameId]);
+    await client.query('COMMIT');
+
+    const gameData = await getAndProcessGameData(gameId, client);
+    io.to(gameId).emit('game-updated', gameData);
+    res.sendStatus(200);
+
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`Error with tag-ups for game ${gameId}:`, error);
+    res.status(500).json({ message: 'Server error during tag-up.' });
+  } finally {
+    client.release();
+  }
+});
+
+// in server.js
+app.post('/api/games/:gameId/initiate-steal', authenticateToken, async (req, res) => {
+  const { gameId } = req.params;
+  const { fromBase } = req.body;
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
+    let newState = stateResult.rows[0].state_data;
+    const currentTurn = stateResult.rows[0].turn_number;
+
+    const { defensiveTeam } = await getActivePlayers(gameId, newState);
+
+    // Set the game state to pause for the defensive throw
+    newState.stealAttempt = { from: fromBase, runner: newState.bases[fromBase === 1 ? 'first' : 'second'] };
+
+    // Pass the turn to the defensive player
+    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.user_id, gameId]);
+    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
+
+    await client.query('COMMIT');
+    const gameData = await getAndProcessGameData(gameId, client);
+    io.to(gameId).emit('game-updated', gameData);
+    res.sendStatus(200);
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`Error initiating steal for game ${gameId}:`, error);
+    res.status(500).json({ message: 'Server error during steal initiation.' });
+  } finally {
+    client.release();
+  }
+});
+
+// in server.js
+app.post('/api/games/:gameId/resolve-steal', authenticateToken, async (req, res) => {
+  const { gameId } = req.params;
+  const userId = req.user.userId;
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
+
+    const originalState = stateResult.rows[0].state_data;
+
+    // ADD THIS DEBUG LOG
+    console.log('--- FULL STATE ON STEAL RESOLUTION ---');
+    console.log(JSON.stringify(originalState, null, 2));
+
+    const currentTurn = stateResult.rows[0].turn_number;
+    let newState = JSON.parse(JSON.stringify(originalState));
+
+    const { offensiveTeam, defensiveTeam } = await getActivePlayers(gameId, newState);
+    const { fromBase, runner } = newState.stealAttempt;
+
+    const catcherInfo = defensiveTeam.lineup.battingOrder.find(p => p.position === 'C');
+    const catcherCard = await pool.query('SELECT fielding_ratings FROM cards_player WHERE card_id = $1', [catcherInfo.card_id]);
+    const catcherArm = catcherCard.rows[0].fielding_ratings['C'] || 0;
+
+    const throwRoll = Math.floor(Math.random() * 20) + 1;
+    const catcherTotal = catcherArm + throwRoll;
+    const isSafe = runner.speed > catcherTotal;
+
+    const events = [];
+    const baseMap = { 1: 'first', 2: 'second' };
+
+    // --- FINAL DEBUG LOGS ---
+    console.log('--- RESOLVE STEAL DEBUG ---');
+    console.log(`Steal from base ${fromBase}. Runner is ${runner.name}. Outcome: ${isSafe ? 'SAFE' : 'OUT'}`);
+
+    const newBases = { ...newState.bases };
+    newBases[baseMap[fromBase]] = null;
+
+    if (isSafe) {
+      console.log(`Runner was SAFE. Moving from ${baseMap[fromBase]}...`);
+      if (fromBase === 1) newBases.second = runner;
+      if (fromBase === 2) newBases.third = runner;
+      events.push(`${runner.name} steals and is SAFE! (Speed ${runner.speed} vs. Throw ${catcherTotal})`);
+      console.log('Bases object after moving runner:', JSON.stringify(newBases));
+    } else {
+      newState.outs++;
+      events.push(`${runner.name} is CAUGHT STEALING! (Speed ${runner.speed} vs. Throw ${catcherTotal})`);
+    }
+
+    newState.bases = newBases;
+    newState.stealAttempt = null;
+    newState.stealRollResult = { catcherArm, throwRoll, total: catcherTotal, outcome: isSafe ? 'Safe' : 'Out' };
+
+    if (newState.outs >= 3) {
+        const wasTop = newState.isTopInning;
+        newState.isTopInning = !newState.isTopInning;
+        if (newState.isTopInning) newState.inning++;
+        newState.outs = 0;
+        newState.bases = { first: null, second: null, third: null };
+    }
+
+    console.log('Final Bases to be Saved:', JSON.stringify(newState.bases));
+
+    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
+    for (const logMessage of events) {
+        await client.query(`INSERT INTO game_events (game_id, user_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4, $5)`, [gameId, offensiveTeam.user_id, currentTurn + 1, 'steal', logMessage]);
+    }
+
+    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.user_id, gameId]);
+    await client.query('COMMIT');
+
+    const gameData = await getAndProcessGameData(gameId, client);
+    io.to(gameId).emit('game-updated', gameData);
+    res.status(200).json({ message: 'Steal resolved.' });
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`Error resolving steal for game ${gameId}:`, error);
+    res.status(500).json({ message: 'Server error during steal.' });
+  } finally {
+    client.release();
+  }
+});
+
+// in server.js
+app.post('/api/games/:gameId/advance-runners', authenticateToken, async (req, res) => {
+  const { gameId } = req.params;
+  const { decisions } = req.body; // e.g., { '1': true, '2': false }
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+    const stateResult = await client.query('SELECT * FROM game_states WHERE game_id = $1 ORDER BY turn_number DESC LIMIT 1', [gameId]);
+    let currentState = stateResult.rows[0].state_data;
+    const currentTurn = stateResult.rows[0].turn_number;
+
+    const { defensiveTeam } = await getActivePlayers(gameId, currentState);
+    const outfieldDefense = await getOutfieldDefense(defensiveTeam);
+
+    const events = [];
+    let newState = JSON.parse(JSON.stringify(currentState));
+
+    // Resolve each baserunning decision
+    for (const fromBase in decisions) {
+      if (decisions[fromBase]) { // If the manager chose to send this runner
+        const runner = fromBase === '1' ? newState.bases.first : newState.bases.second;
+        if (!runner) continue;
+
+        const throwRoll = Math.floor(Math.random() * 20) + 1;
+        let speed = runner.speed;
+
+        // Apply modifiers
+        if (newState.outs === 2) speed += 5;
+        if (fromBase === '2') speed += 5; // Runner from 2nd is trying to score (going home)
+
+        const defenseTotal = outfieldDefense + throwRoll;
+
+        if (speed > defenseTotal) {
+          // SAFE!
+          if (fromBase === '1') { newState.bases.third = runner; newState.bases.first = null; }
+          if (fromBase === '2') { newState[newState.isTopInning ? 'awayScore' : 'homeScore']++; newState.bases.second = null; }
+          events.push(`${runner.name} advances an extra base and is SAFE! (Speed ${speed} vs Defense ${defenseTotal})`);
+        } else {
+          // OUT!
+          newState.outs++;
+          if (fromBase === '1') newState.bases.first = null;
+          if (fromBase === '2') newState.bases.second = null;
+          events.push(`${runner.name} is THROWN OUT trying to advance! (Speed ${speed} vs Defense ${defenseTotal})`);
+        }
+      }
+    }
+
+    // Finalize the turn
+    newState.baserunningDecisions = null;
+    const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
+    newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
+
+    // Check for inning end after the play
+    if (newState.outs >= 3) {
+      newState.isTopInning = !newState.isTopInning;
+      if (newState.isTopInning) newState.inning++;
+      newState.outs = 0;
+      newState.bases = { first: null, second: null, third: null };
+      // This is now handled by the inningChangeEvent logic
+    }
+
+    await client.query('INSERT INTO game_states (game_id, turn_number, state_data, is_between_half_innings_home, is_between_half_innings_away) VALUES ($1, $2, $3, $4, $5)', [gameId, currentTurn + 1, newState, newState.isBetweenHalfInningsHome, newState.isBetweenHalfInningsAway]);
+    for (const logMessage of events) {
+      await client.query(`INSERT INTO game_events (game_id, turn_number, event_type, log_message) VALUES ($1, $2, $3, $4)`, [gameId, currentTurn + 1, 'baserunning', logMessage]);
+    }
+    await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.userId, gameId]);
+    await client.query('COMMIT');
+
+    const gameData = await getAndProcessGameData(gameId, client);
+    io.to(gameId).emit('game-updated', gameData);
+    res.sendStatus(200);
+
+  } catch (error) {
+    await client.query('ROLLBACK');
+    console.error(`Error advancing runners for game ${gameId}:`, error);
+    res.status(500).json({ message: 'Server error during baserunning.' });
+  } finally {
+    client.release();
+  }
+});
 
 // --- HELPER: Determines the mandatory starting pitcher for a series game ---
 async function getMandatoryPitcher(gameId, userId, dbClient) {

--- a/apps/backend/update-display-names.js
+++ b/apps/backend/update-display-names.js
@@ -1,13 +1,16 @@
 require('dotenv').config();
 const { Pool } = require('pg');
 
-const dbConfig = {
-  user: process.env.PGUSER,
-  host: process.env.PGHOST,
-  database: process.env.PGDATABASE,
-  password: process.env.PGPASSWORD,
-  port: process.env.PGPORT,
-};
+// Use DATABASE_URL if available (for Render), otherwise fall back to .env variables
+const dbConfig = process.env.DATABASE_URL
+  ? { connectionString: process.env.DATABASE_URL }
+  : {
+      user: process.env.PGUSER,
+      host: process.env.PGHOST,
+      database: process.env.PGDATABASE,
+      password: process.env.PGPASSWORD,
+      port: process.env.PGPORT,
+    };
 
 const pool = new Pool(dbConfig);
 

--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -59,14 +59,6 @@ const linescore = computed(() => {
 
 const awayTeamAbbr = computed(() => gameStore.teams?.away?.abbreviation || 'AWAY');
 const homeTeamAbbr = computed(() => gameStore.teams?.home?.abbreviation || 'HOME');
-
-const awayTotalRuns = computed(() => {
-  return linescore.value.scores.away.reduce((total, runs) => total + runs, 0);
-});
-
-const homeTotalRuns = computed(() => {
-  return linescore.value.scores.home.reduce((total, runs) => total + runs, 0);
-});
 </script>
 
 <template>
@@ -87,7 +79,7 @@ const homeTotalRuns = computed(() => {
             :class="{ 'current-inning': gameStore.gameState?.isTopInning && (index + 1) === gameStore.gameState?.inning }"
           >{{ run }}</td>
           <td v-for="i in linescore.innings.length - linescore.scores.away.length" :key="`away-empty-${i}`"></td>
-          <td>{{ awayTotalRuns }}</td>
+          <td>{{ gameStore.gameState?.awayScore }}</td>
         </tr>
         <tr>
           <td>{{ homeTeamAbbr }}</td>
@@ -97,7 +89,7 @@ const homeTotalRuns = computed(() => {
             :class="{ 'current-inning': !gameStore.gameState?.isTopInning && (index + 1) === gameStore.gameState?.inning }"
           >{{ run }}</td>
           <td v-for="i in linescore.innings.length - linescore.scores.home.length" :key="`home-empty-${i}`"></td>
-          <td>{{ homeTotalRuns }}</td>
+          <td>{{ gameStore.gameState?.homeScore }}</td>
         </tr>
       </tbody>
     </table>

--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -280,27 +280,26 @@ async function declareHomeTeam(gameId, homeTeamUserId) {
   }
 }
 
-async function initiateSteal(gameId, decisions) {
+async function initiateSteal(gameId, fromBase) {
     const auth = useAuthStore();
     if (!auth.token) return;
     try {
       await fetch(`${auth.API_URL}/api/games/${gameId}/initiate-steal`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${auth.token}` },
-        body: JSON.stringify({ decisions })
+        body: JSON.stringify({ fromBase })
       });
     } catch (error) { console.error("Error initiating steal:", error); }
   }
 
 
-async function resolveSteal(gameId, throwTo) {
+async function resolveSteal(gameId) {
     const auth = useAuthStore();
     if (!auth.token) return;
     try {
       await fetch(`${auth.API_URL}/api/games/${gameId}/resolve-steal`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${auth.token}` },
-        body: JSON.stringify({ throwTo })
+        headers: { 'Authorization': `Bearer ${auth.token}` }
       });
     } catch (error) { console.error("Error resolving steal:", error); }
   }

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -26,23 +26,7 @@ const choices = ref({});
 
 const selectedCard = ref(null);
 const playerToSubIn = ref(null);
-const runnerDecisionChoices = ref({});
-
-const isAdvancementOrTagUpDecision = computed(() => {
-    if (!amIOffensivePlayer.value || !isMyTurn.value || !gameStore.gameState?.currentPlay) {
-        return false;
-    }
-    const type = gameStore.gameState.currentPlay.type;
-    return type === 'ADVANCE' || type === 'TAG_UP';
-});
-
-const isDefensiveThrowDecision = computed(() => {
-    if (!amIDefensivePlayer.value || !isMyTurn.value || !gameStore.gameState?.currentPlay) {
-        return false;
-    }
-    const { type, payload } = gameStore.gameState.currentPlay;
-    return (type === 'ADVANCE' || type === 'TAG_UP') && payload && payload.choices;
-});
+const baserunningChoices = ref({});
 // NEW: Local state for the checkbox
 
 const infieldIn = ref(gameStore.gameState?.infieldIn || false);
@@ -253,20 +237,20 @@ watch(shouldHidePlayOutcome, (newValue) => {
 const offensiveChoiceMade = computed(() => !!gameStore.gameState?.currentAtBat?.batterAction);
 
 const canAttemptSteal = computed(() => {
-    // Stealing is an offensive action, must be their turn, and no other play can be in progress.
-    if (!amIOffensivePlayer.value || !isMyTurn.value || !gameStore.gameState || gameStore.gameState.currentPlay) {
-        return false;
-    }
-    const { bases } = gameStore.gameState;
-    const canStealSecond = bases.first && !bases.second;
-    const canStealThird = bases.second && !bases.third;
-    // It's possible to steal if at least one of these conditions is met.
-    return canStealSecond || canStealThird;
+  if (!amIOffensivePlayer.value || !gameStore.gameState || !gameStore.gameState.currentAtBat) {
+    return false;
+  }
+  // Can only steal after the pitch but before the swing
+  if (!gameStore.gameState.currentAtBat.pitcherAction || gameStore.gameState.currentAtBat.batterAction) {
+    return false;
+  }
+  const { bases } = gameStore.gameState;
+  // Can steal 2nd if runner on 1st and 2nd is empty
+  const canStealSecond = bases.first && !bases.second;
+  // Can steal 3rd if runner on 2nd and 3rd is empty
+  const canStealThird = bases.second && !bases.third;
+  return canStealSecond || canStealThird;
 });
-
-const canStealSecond = computed(() => canAttemptSteal.value && gameStore.gameState.bases.first && !gameStore.gameState.bases.second);
-const canStealThird = computed(() => canAttemptSteal.value && gameStore.gameState.bases.second && !gameStore.gameState.bases.third);
-const canDoubleSteal = computed(() => canAttemptSteal.value && gameStore.gameState.bases.first && gameStore.gameState.bases.second && !gameStore.gameState.bases.third);
 
 const showNextHitterButton = computed(() => {
   if (amIReadyForNext.value) {
@@ -581,14 +565,9 @@ function hexToRgba(hex, alpha = 0.95) {
   return `rgba(${[(c>>16)&255, (c>>8)&255, c&255].join(',')},${alpha})`;
 }
 
-function handleInitiateSteal(decisions) {
-    gameStore.initiateSteal(gameId, decisions);
+function handleInitiateSteal() {
+    gameStore.initiateSteal(gameId);
 }
-
-function handleResolveSteal(throwTo) {
-    gameStore.resolveSteal(gameId, throwTo);
-}
-
 function handlePitch(action = null) {
   console.log('1. GameView: handlePitch function was called.');
   gameStore.submitPitch(gameId, action);
@@ -617,38 +596,46 @@ function handleNextHitter() {
   gameStore.nextHitter(gameId);
 }
 
-function handleRunnerDecisions() {
-    gameStore.submitBaserunningDecisions(gameId, runnerDecisionChoices.value);
-    runnerDecisionChoices.value = {}; // Reset choices
+// in GameView.vue
+function handleThrowForSteal() {
+  console.log('1. "Roll for Throw" button was clicked.');
+  gameStore.resolveSteal(gameId);
 }
-
-function handleDefensiveThrow(base) {
+function confirmBaserunning() {
+  console.log('1. "Confirm Decisions" button clicked. Sending:', baserunningChoices.value);
+  gameStore.advanceRunners(gameId, baserunningChoices.value);
+  baserunningChoices.value = {};
+}
+function confirmTagUp() {
+    gameStore.submitTagUp(gameId, tagUpChoices.value);
+    tagUpChoices.value = {}; // Reset choices
+}
+function confirmOffensiveDecisions() {
+    gameStore.submitBaserunningDecisions(gameId, baserunningChoices.value);
+    baserunningChoices.value = {};
+}
+function makeDefensiveThrow(base) {
     gameStore.resolveDefensiveThrow(gameId, base);
 }
 
+function handleStealAttempt(fromBase) {
+  if (!canAttemptSteal.value) {
+      console.log('Steal aborted: canAttemptSteal is false.');
+      return;
+  }
+  if (confirm(`Are you sure you want to attempt to steal from base ${fromBase}?`)) {
+      gameStore.initiateSteal(gameId, fromBase);
+  }
+}
 
-const isStealAttemptInProgress = computed(() => gameStore.gameState?.currentPlay?.type === 'STEAL_ATTEMPT');
-
-const isInfieldInDecision = computed(() => {
-    return amIOffensivePlayer.value && isMyTurn.value && gameStore.gameState?.currentPlay?.type === 'INFIELD_IN_PLAY';
-});
-
-const isPitcherTired = (pitcher) => {
-    if (!pitcher || !gameStore.gameState?.pitcherStats) {
-        return false;
-    }
-    const stats = gameStore.gameState.pitcherStats[pitcher.card_id];
-    if (!stats) {
-        return false;
-    }
-    const fatigueThreshold = pitcher.ip - Math.floor(stats.runs / 3);
-    return stats.ip > fatigueThreshold;
-};
+const isStealAttemptInProgress = computed(() => !!gameStore.gameState.stealAttempt);
 
 // in GameView.vue <script setup>
 
 function handleInfieldInDecision(sendRunner) {
-    gameStore.submitInfieldInDecision(gameId, sendRunner);
+
+    gameStore.submitInfieldInDecision(gameId, sendRunner);
+
 }
 
 
@@ -877,7 +864,7 @@ onUnmounted(() => {
 
       <!-- BASEBALL DIAMOND AND RESULTS -->
       <div class="diamond-and-results-container">
-          <BaseballDiamond :bases="basesToDisplay" :canSteal="false" :isStealAttemptInProgress="isStealAttemptInProgress" :catcherArm="catcherArm" />
+          <BaseballDiamond :bases="basesToDisplay" :canSteal="canAttemptSteal" :isStealAttemptInProgress="isStealAttemptInProgress" :catcherArm="catcherArm" @attempt-steal="handleStealAttempt" />
           <div v-if="atBatToDisplay.pitchRollResult &&
            (gameStore.gameState.currentAtBat.pitchRollResult || !amIReadyForNext.value && opponentReadyForNext) &&
             !(!bothPlayersSetAction.value && amIDisplayOffensivePlayer && !atBatToDisplay.batterAction)" :class="pitchResultClasses" :style="{ backgroundColor: hexToRgba(pitcherTeamColors.primary), borderColor: hexToRgba(pitcherTeamColors.secondary), color: pitcherResultTextColor }">
@@ -895,68 +882,20 @@ onUnmounted(() => {
         <!-- Actions (for layout purposes) -->
         <div class="actions-container">
             <!-- Main Action Buttons -->
-            <div v-if="isAdvancementOrTagUpDecision">
-                <h3>Runner Decisions</h3>
-                <p>Select which runners to send:</p>
-                <div v-for="decision in gameStore.gameState.currentPlay.payload.decisions" :key="decision.from" class="decision-checkbox">
-                    <label>
-                        <input type="checkbox" v-model="runnerDecisionChoices[decision.from]" />
-                        Send {{ decision.runner.name }} (from {{ decision.from }}B)
-                    </label>
-                </div>
-                <button @click="handleRunnerDecisions" class="tactile-button">Confirm Decisions</button>
-            </div>
-            <div v-else-if="isDefensiveThrowDecision">
-                <h3>Defensive Throw</h3>
-                <p>Opponent is sending runners! Choose where to throw:</p>
-                <button v-for="(sent, fromBase) in gameStore.gameState.currentPlay.payload.choices"
-                        :key="fromBase"
-                        v-if="sent"
-                        @click="handleDefensiveThrow(parseInt(fromBase, 10) + 1)"
-                        class="tactile-button">
-                    Throw to {{ parseInt(fromBase, 10) + 1 }}B
-                </button>
-            </div>
-            <div v-else-if="isStealAttemptInProgress && amIDefensivePlayer">
-                <h3>Opponent is stealing!</h3>
-                <p>Choose which base to throw to:</p>
-                <button @click="handleResolveSteal(2)" v-if="gameStore.gameState.currentPlay.payload.decisions['1']" class="tactile-button">Throw to 2nd</button>
-                <button @click="handleResolveSteal(3)" v-if="gameStore.gameState.currentPlay.payload.decisions['2']" class="tactile-button">Throw to 3rd</button>
-            </div>
-            <div v-else-if="isStealAttemptInProgress && amIOffensivePlayer">
-                <div class="waiting-text">Waiting for opponent to throw...</div>
-            </div>
-            <div v-else-if="isInfieldInDecision">
-                <h3>Infield In Play</h3>
-                <p>The defense has the infield in. What will the runner on third do?</p>
-                <button @click="handleInfieldInDecision(true)" class="tactile-button">Send Runner Home</button>
-                <button @click="handleInfieldInDecision(false)" class="tactile-button">Hold Runner</button>
-            </div>
-            <div v-else>
-                <button v-if="amIDisplayDefensivePlayer && !gameStore.gameState.currentAtBat.pitcherAction && !(!amIReadyForNext && (gameStore.gameState.awayPlayerReadyForNext || gameStore.gameState.homePlayerReadyForNext))" class="action-button tactile-button" @click="handlePitch()"><strong>ROLL FOR PITCH</strong></button>
-                <button v-if="amIDisplayOffensivePlayer && !gameStore.gameState.currentAtBat.batterAction && (amIReadyForNext || bothPlayersCaughtUp)" class="action-button tactile-button" @click="handleOffensiveAction('swing')"><strong>Swing Away</strong></button>
-                <button v-else-if="amIDisplayOffensivePlayer && !haveIRolledForSwing && (bothPlayersSetAction || opponentReadyForNext)" class="action-button tactile-button" @click="handleSwing()"><strong>ROLL FOR SWING </strong></button>
-                <button v-if="showNextHitterButton && (isSwingResultVisible || (amIDisplayOffensivePlayer && haveIRolledForSwing))" class="action-button tactile-button" @click="handleNextHitter()"><strong>Next Hitter</strong></button>
+            <button v-if="amIDisplayDefensivePlayer && !gameStore.gameState.currentAtBat.pitcherAction && !(!amIReadyForNext && (gameStore.gameState.awayPlayerReadyForNext || gameStore.gameState.homePlayerReadyForNext))" class="action-button tactile-button" @click="handlePitch()"><strong>ROLL FOR PITCH</strong></button>
+            <button v-if="amIDisplayOffensivePlayer && !gameStore.gameState.currentAtBat.batterAction && (amIReadyForNext || bothPlayersCaughtUp)" class="action-button tactile-button" @click="handleOffensiveAction('swing')"><strong>Swing Away</strong></button>
+            <button v-else-if="amIDisplayOffensivePlayer && !haveIRolledForSwing && (bothPlayersSetAction || opponentReadyForNext)" class="action-button tactile-button" @click="handleSwing()"><strong>ROLL FOR SWING </strong></button>
+            <button v-if="showNextHitterButton && (isSwingResultVisible || (amIDisplayOffensivePlayer && haveIRolledForSwing))" class="action-button tactile-button" @click="handleNextHitter()"><strong>Next Hitter</strong></button>
 
-                <!-- Secondary Action Buttons -->
-                <div class="secondary-actions">
-                    <button v-if="amIDisplayDefensivePlayer && !gameStore.gameState.currentAtBat.pitcherAction && !(!amIReadyForNext && (gameStore.gameState.awayPlayerReadyForNext || gameStore.gameState.homePlayerReadyForNext))" class="tactile-button" @click="handlePitch('intentional_walk')">Intentional Walk</button>
-                    <div v-if="amIDisplayDefensivePlayer && !gameStore.gameState.currentAtBat.pitcherAction && !(!amIReadyForNext && (gameStore.gameState.awayPlayerReadyForNext || gameStore.gameState.homePlayerReadyForNext))" class="infield-in-checkbox">
-                        <label>
-                            <input type="checkbox" v-model="infieldIn" />
-                            Infield In
-                        </label>
-                    </div>
-                    <button v-if="amIDisplayOffensivePlayer && !gameStore.gameState.currentAtBat.batterAction && (amIReadyForNext || bothPlayersCaughtUp)" class="tactile-button" @click="handleOffensiveAction('bunt')">Bunt</button>
-                    <button v-if="canStealSecond" @click="handleInitiateSteal({ '1': true })" class="tactile-button">Steal 2nd</button>
-                    <button v-if="canStealThird" @click="handleInitiateSteal({ '2': true })" class="tactile-button">Steal 3rd</button>
-                    <button v-if="canDoubleSteal" @click="handleInitiateSteal({ '1': true, '2': true })" class="tactile-button">Double Steal</button>
-                </div>
+            <!-- Secondary Action Buttons -->
+            <div>
+                <button v-if="amIDisplayDefensivePlayer && !gameStore.gameState.currentAtBat.pitcherAction && !(!amIReadyForNext && (gameStore.gameState.awayPlayerReadyForNext || gameStore.gameState.homePlayerReadyForNext))" class="tactile-button" @click="handlePitch('intentional_walk')">Intentional Walk</button>
+                <button v-if="amIDisplayOffensivePlayer && !gameStore.gameState.currentAtBat.batterAction && (amIReadyForNext || bothPlayersCaughtUp)" class="tactile-button" @click="handleOffensiveAction('bunt')">Bunt</button>
             </div>
 
             <!-- Waiting Indicators -->
-            <div v-if="amIDisplayOffensivePlayer && gameStore.gameState.currentAtBat.batterAction && !gameStore.gameState.currentAtBat.pitcherAction && !isStealAttemptInProgress && !isAdvancementOrTagUpDecision && !isDefensiveThrowDecision" class="waiting-text">Waiting for pitch...</div>
-            <div v-if="(amIDisplayDefensivePlayer && gameStore.gameState.currentAtBat.pitcherAction && !gameStore.gameState.currentAtBat.batterAction) && !isStealAttemptInProgress && !isAdvancementOrTagUpDecision && !isDefensiveThrowDecision" class="turn-indicator">Waiting for swing...</div>
+            <div v-if="amIDisplayOffensivePlayer && gameStore.gameState.currentAtBat.batterAction && !gameStore.gameState.currentAtBat.pitcherAction" class="waiting-text">Waiting for pitch...</div>
+            <div v-if="(amIDisplayDefensivePlayer && gameStore.gameState.currentAtBat.pitcherAction && !gameStore.gameState.currentAtBat.batterAction)" class="turn-indicator">Waiting for swing...</div>
         </div>
 
         <!-- Player Cards Wrapper -->
@@ -1007,7 +946,7 @@ onUnmounted(() => {
           <div v-if="leftPanelData.pitcher" class="pitcher-info"
                :class="{'sub-target': playerToSubIn && leftPanelData.isMyTeam}"
                @click="executeSubstitution(leftPanelData.pitcher, 'P')">
-              <hr /><strong :style="{ color: leftPanelData.colors.primary }">Pitching:</strong> {{ leftPanelData.pitcher.name }} <span v-if="isPitcherTired(leftPanelData.pitcher)" class="tired-indicator">(Tired)</span>
+              <hr /><strong :style="{ color: leftPanelData.colors.primary }">Pitching:</strong> {{ leftPanelData.pitcher.name }}
           </div>
           <div v-if="leftPanelData.bullpen.length > 0">
               <hr /><strong :style="{ color: leftPanelData.colors.primary }">Bullpen:</strong>
@@ -1068,7 +1007,7 @@ onUnmounted(() => {
           <div v-if="rightPanelData.pitcher" class="pitcher-info"
                :class="{'sub-target': playerToSubIn && rightPanelData.isMyTeam}"
                @click="executeSubstitution(rightPanelData.pitcher, 'P')">
-              <hr /><strong :style="{ color: rightPanelData.colors.primary }">Pitching:</strong> {{ rightPanelData.pitcher.name }} <span v-if="isPitcherTired(rightPanelData.pitcher)" class="tired-indicator">(Tired)</span>
+              <hr /><strong :style="{ color: rightPanelData.colors.primary }">Pitching:</strong> {{ rightPanelData.pitcher.name }}
           </div>
           <div v-if="rightPanelData.bullpen.length > 0">
               <hr /><strong :style="{ color: rightPanelData.colors.primary }">Bullpen:</strong>
@@ -1261,7 +1200,6 @@ onUnmounted(() => {
 .lineup-panel li { cursor: pointer; padding: 2px 0; }
 .lineup-panel li:hover { text-decoration: underline; }
 .pitcher-info { font-weight: bold; margin-top: 0.5rem; }
-.tired-indicator { color: #dc3545; font-weight: bold; font-style: italic; }
 .lineup-panel li.sub-target, .pitcher-info.sub-target { background-color: #ffc107; cursor: crosshair; }
 .lineup-panel ul li.selected { background-color: #007bff; color: white; }
 .now-batting { background-color: #fff8e1; font-weight: bold; font-style: normal !important; color: #000 !important; }
@@ -1311,15 +1249,6 @@ onUnmounted(() => {
   background-color: #F0F0F0;
   width: 100%;
   margin: 0;
-}
-.secondary-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin-top: 1rem;
-}
-.infield-in-checkbox {
-    text-align: center;
 }
 .action-button:hover, .tactile-button:hover { background-color: #E4E4E4; }
 .action-button:active, .tactile-button:active { background-color: #C4C4C4; box-shadow: none; }

--- a/node_modules/showdown-league-app
+++ b/node_modules/showdown-league-app
@@ -1,0 +1,1 @@
+../apps/backend


### PR DESCRIPTION
Updates the `update-display-names.js` script to make it compatible with production environments like Render.

- The script now uses the `DATABASE_URL` environment variable for the database connection if it is available, falling back to individual `PG*` variables for local development. This fixes the `ECONNREFUSED` error when running in production.
- Adds a `prod:update-names` script to `package.json` to facilitate running the script via a build command in environments without shell access.

This also includes the previous refinements to the display name logic:
- Disambiguates players with the same name across the league by adding a team abbreviation.
- Handles multiple cards for the same player on a team by using their role or position.
- Correctly sorts 'OF/SS' positions to 'SS/OF'.