### PR TITLE
fix(backend): Add displayName to player data

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -141,6 +141,7 @@ function processPlayers(playersToProcess) {
     playersToProcess.forEach(p => {
         if (!p) return;
         // displayName is now pre-calculated and stored in the database as display_name
+        p.displayName = p.display_name;
         if (p.control !== null) {
             p.displayPosition = Number(p.ip) > 3 ? 'SP' : 'RP';
         } else {

--- a/jules-scratch/verification/get_token.py
+++ b/jules-scratch/verification/get_token.py
@@ -1,0 +1,17 @@
+import requests
+import os
+
+def get_token():
+    try:
+        response = requests.get("http://localhost:3001/api/dev/get-token/1")
+        response.raise_for_status()  # Raise an exception for bad status codes
+        token = response.json().get("token")
+        if token:
+            print(token)
+        else:
+            print("Token not found in response.")
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching token: {e}")
+
+if __name__ == "__main__":
+    get_token()


### PR DESCRIPTION
The frontend GameView expects player objects to have a `displayName` (camelCase) property to render names in the lineup. Following a recent database update, the backend was sending this property as `display_name` (snake_case), causing the names to disappear from the UI.

This commit fixes the issue by updating the `processPlayers` helper function in `server.js`. It now explicitly creates the `displayName` property on each player object, mapping it from the `display_name` field. This ensures the data sent to the frontend is in the correct format without altering the underlying database schema.