### PR TITLE
Fix UI timing issue on third out reveal

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -349,7 +349,15 @@ async function resetRolls(gameId) {
   const gameEventsToDisplay = computed(() => {
     if (!gameEvents.value) return [];
     if (isOutcomeHidden.value) {
-      // The backend guarantees the last event is the one to hide
+      // If the outcome is hidden and we are now between innings, it means the
+      // last play resulted in the 3rd out. We need to hide TWO events: the
+      // play outcome itself, and the subsequent "inning change" event.
+      const isBetween = gameState.value?.isBetweenHalfInningsAway || gameState.value?.isBetweenHalfInningsHome;
+      if (isBetween) {
+        return gameEvents.value.slice(0, gameEvents.value.length - 2);
+      }
+      // In all other "outcome hidden" cases (e.g., offense waiting to roll),
+      // we only need to hide the single outcome event.
       return gameEvents.value.slice(0, gameEvents.value.length - 1);
     }
     return gameEvents.value;

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -530,17 +530,8 @@ const basesToDisplay = computed(() => {
 });
 
 const outsToDisplay = computed(() => {
-  // NEW: Special condition for the offensive player between innings, before they have rolled.
-  // Show the state of the game as it was before the 3rd out was recorded.
-  const isOffensivePlayerBetweenInnings = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value && isBetweenHalfInnings.value;
-  if (isOffensivePlayerBetweenInnings) {
-    // We want to show the number of outs from the *previous* at-bat.
-    return gameStore.gameState?.lastCompletedAtBat?.outsBeforePlay || 0;
-  }
-
-  if (isBetweenHalfInnings.value) {
-    return 3;
-  }
+  // NEW: Always prioritize hiding the outcome if needed. This prevents the
+  // UI from jumping to 3 outs before the final out is revealed.
   if (shouldHidePlayOutcome.value) {
     if (opponentReadyForNext.value) {
       return gameStore.gameState?.lastCompletedAtBat?.outsBeforePlay || 0;
@@ -548,7 +539,20 @@ const outsToDisplay = computed(() => {
       return gameStore.gameState?.currentAtBat?.outsBeforePlay || 0;
     }
   }
-  
+
+  // Special condition for the offensive player between innings, before they have rolled.
+  // Show the state of the game as it was before the 3rd out was recorded.
+  const isOffensivePlayerBetweenInnings = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value && isBetweenHalfInnings.value;
+  if (isOffensivePlayerBetweenInnings) {
+    // We want to show the number of outs from the *previous* at-bat.
+    return gameStore.gameState?.lastCompletedAtBat?.outsBeforePlay || 0;
+  }
+
+  // If the inning is over and the outcome is not hidden, show 3 outs.
+  if (isBetweenHalfInnings.value) {
+    return 3;
+  }
+
   // Otherwise, show the current, live number of outs.
   return gameStore.gameState?.outs;
 });


### PR DESCRIPTION
When the defensive player's action resulted in a third out, the UI would update the outs display and the linescore before the swing result was visually revealed after its 900ms delay. This spoiled the outcome of the play.

This commit addresses the issue in two ways:

1.  The `outsToDisplay` computed property in `GameView.vue` is refactored to prioritize the `shouldHidePlayOutcome` check. This ensures that the UI continues to show the `outsBeforePlay` value during the reveal delay, even when it's the third out.

2.  The `gameEventsToDisplay` computed property in the `game.js` store is made more intelligent. When an outcome is hidden and the game is between innings, it now correctly hides both the play result and the subsequent inning change event from the log. This prevents the linescore, which is derived from these events, from updating prematurely.