### PR TITLE
fix(ui): Correct linescore and game log display between innings

### DIFF
--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -41,14 +41,16 @@ const linescore = computed(() => {
   });
   
   if (gameStore.isBetweenHalfInnings) {
-    // In this specific state, don't add the optimistic '0' for the next inning
+    // In this specific state, the inning is over. Add the final score.
+    if (isTop) {
+      scores.away.push(awayRunsInInning);
+    } else {
+      scores.home.push(homeRunsInInning);
+    }
   } else if (isTop) {
     scores.away.push(awayRunsInInning);
   } else {
     if(scores.away.length === scores.home.length) {
-      // When we're in the bottom of an inning, the away team's runs for this inning are final.
-      // The awayRunsInInning variable should have been reset to 0 by the last inning-change event.
-      // Pushing 0 is the correct action.
       scores.away.push(0);
     }
     scores.home.push(homeRunsInInning);
@@ -84,7 +86,7 @@ const homeTotalRuns = computed(() => {
           <td 
             v-for="(run, index) in linescore.scores.away" 
             :key="`away-${index}`"
-            :class="{ 'current-inning': gameStore.gameState?.isTopInning && (index + 1) === gameStore.gameState?.inning }"
+            :class="{ 'current-inning': gameStore.gameState?.isTopInning && (index + 1) === gameStore.gameState?.inning && !gameStore.isBetweenHalfInnings }"
           >{{ run }}</td>
           <td v-for="i in linescore.innings.length - linescore.scores.away.length" :key="`away-empty-${i}`"></td>
           <td>{{ awayTotalRuns }}</td>
@@ -94,7 +96,7 @@ const homeTotalRuns = computed(() => {
           <td 
             v-for="(run, index) in linescore.scores.home" 
             :key="`home-${index}`"
-            :class="{ 'current-inning': !gameStore.gameState?.isTopInning && (index + 1) === gameStore.gameState?.inning }"
+            :class="{ 'current-inning': !gameStore.gameState?.isTopInning && (index + 1) === gameStore.gameState?.inning && !gameStore.isBetweenHalfInnings }"
           >{{ run }}</td>
           <td v-for="i in linescore.innings.length - linescore.scores.home.length" :key="`home-empty-${i}`"></td>
           <td>{{ homeTotalRuns }}</td>

--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -392,9 +392,14 @@ async function resetRolls(gameId) {
     isOutcomeHidden.value = false;
   }
 
+  const isBetweenHalfInnings = computed(() => {
+    if (!gameState.value) return false;
+    return gameState.value.isBetweenHalfInningsAway || gameState.value.isBetweenHalfInningsHome;
+  });
+
   return { game, series, gameState, gameEvents, batter, pitcher, lineups, rosters, setupState, teams,
     fetchGame, declareHomeTeam,setGameState,initiateSteal,resolveSteal,submitPitch, submitSwing, fetchGameSetup, submitRoll, submitGameSetup,submitTagUp,
-    displayOuts, setDisplayOuts, isOutcomeHidden, setOutcomeHidden, gameEventsToDisplay,
+    displayOuts, setDisplayOuts, isOutcomeHidden, setOutcomeHidden, gameEventsToDisplay, isBetweenHalfInnings,
     submitBaserunningDecisions,submitAction,nextHitter,resolveDefensiveThrow,submitSubstitution, advanceRunners,setDefense,submitInfieldInDecision,resetRolls,
     updateGameData,
     resetGameState

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -190,15 +190,11 @@ const amIDefensivePlayer = computed(() => {
     return !amIOffensivePlayer.value;
 });
 
-const isBetweenHalfInnings = computed(() => {
-  if (!gameStore.gameState) return false;
-  return gameStore.gameState.isBetweenHalfInningsAway || gameStore.gameState.isBetweenHalfInningsHome;
-});
 
 // NEW: A display-only computed to handle inning-change visuals
 const isDisplayTopInning = computed(() => {
   if (!gameStore.gameState) return null;
-  if (isBetweenHalfInnings.value) {
+  if (gameStore.isBetweenHalfInnings) {
     return !gameStore.gameState.isTopInning;
   }
   return gameStore.gameState.isTopInning;
@@ -206,7 +202,7 @@ const isDisplayTopInning = computed(() => {
 
 // NEW: Display-only computeds for the inning changeover
 const amIDisplayOffensivePlayer = computed(() => {
-  if (isBetweenHalfInnings.value) {
+  if (gameStore.isBetweenHalfInnings) {
     return !amIOffensivePlayer.value;
   }
   return amIOffensivePlayer.value;
@@ -274,7 +270,7 @@ const showNextHitterButton = computed(() => {
   }
 
   // Case 1: Inning is over. Both players see the button.
-  if (isBetweenHalfInnings.value) {
+  if (gameStore.isBetweenHalfInnings) {
     if (amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value) {
     return false;
   } else{
@@ -326,7 +322,7 @@ const awayTeamColors = computed(() => {
 });
 
 const eventsForLog = computed(() => {
-    const hideTwoEvents = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value && isBetweenHalfInnings.value;
+    const hideTwoEvents = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value && gameStore.isBetweenHalfInnings;
 
     if (hideTwoEvents) {
         // This is our special case. The backend sends the full event log.
@@ -541,7 +537,7 @@ const outsToDisplay = computed(() => {
 
   // Special condition for the offensive player between innings, before they have rolled.
   // Show the state of the game as it was before the 3rd out was recorded.
-  const isOffensivePlayerBetweenInnings = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value && isBetweenHalfInnings.value;
+  const isOffensivePlayerBetweenInnings = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value && gameStore.isBetweenHalfInnings;
   if (isOffensivePlayerBetweenInnings) {
     if (opponentReadyForNext.value) {
       return gameStore.gameState?.lastCompletedAtBat?.outsBeforePlay || 0;
@@ -551,7 +547,7 @@ const outsToDisplay = computed(() => {
   }
 
   // If the inning is over and the outcome is not hidden, show 3 outs.
-  if (isBetweenHalfInnings.value) {
+  if (gameStore.isBetweenHalfInnings) {
     return 3;
   }
 


### PR DESCRIPTION
This commit fixes a UI bug that occurred between half-innings, ensuring the linescore and game log display correctly while waiting for the user to proceed to the next hitter.

- Centralized the `isBetweenHalfInnings` logic into the `game.js` store to provide a single source of truth and improve code consistency.
- Corrected the `Linescore.vue` component to properly display the final score of the just-completed inning without showing a premature score for the upcoming inning.
- Fixed the inning highlighting in `Linescore.vue` to prevent any inning from being highlighted when the game is between half-innings.
- Refactored `GameView.vue` to use the new centralized `isBetweenHalfInnings` property from the store, removing redundant local logic.