### PR TITLE
Fix(frontend): Adjust linescore layout on mobile

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -108,7 +108,8 @@ const isGamePage = computed(() => route.name === 'game');
   .nav-center {
     flex-grow: 1; /* Allow this to fill available space */
     min-width: 0; /* Critical for flex-grow in a flex container */
-    justify-content: space-between; /* Pushes Linescore and Outs apart */
+    justify-content: center; /* Center the items */
+    gap: 1rem; /* Add some space between items */
   }
 
   /* REMOVED: The transform was causing the overlap issue.
@@ -122,6 +123,10 @@ const isGamePage = computed(() => route.name === 'game');
     display: none;
   }
 
+  .global-nav.game-page-active .nav-team-logo {
+    display: none;
+  }
+
   /* Ensure the outs are visible against the dark background */
   .nav-center :deep(.outs-display) {
     background-color: transparent; /* Or whatever matches the nav */
@@ -129,7 +134,6 @@ const isGamePage = computed(() => route.name === 'game');
   }
 
   .nav-center :deep(.linescore-table) {
-    flex: 1 1 0;
     min-width: 0;
   }
 }

--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -157,7 +157,7 @@ const homeTotalRuns = computed(() => {
   }
   .linescore-table th,
   .linescore-table td {
-    min-width: unset;
+    min-width: 20px;
     padding: 0.1rem;
   }
   .linescore-table td:first-child {


### PR DESCRIPTION
The linescore component was being unnecessarily compressed on mobile devices due to flexbox settings in the global navigation bar.

This change adjusts the flexbox properties to center the linescore and outs display, preventing the linescore from shrinking excessively. It also hides the team logo on the game page for mobile to prevent content overlap.