### PR TITLE
feat(frontend): Adjust linescore spacing on mobile

### DIFF
--- a/apps/frontend/src/components/Linescore.vue
+++ b/apps/frontend/src/components/Linescore.vue
@@ -157,8 +157,8 @@ const homeTotalRuns = computed(() => {
   }
   .linescore-table th,
   .linescore-table td {
-    min-width: 20px;
-    padding: 0.1rem;
+    min-width: 22px;
+    padding: 0.1rem 0.2rem;
   }
   .linescore-table td:first-child {
     min-width: unset;


### PR DESCRIPTION
The linescore table was previously too cramped on mobile devices. This change increases the `min-width` of the table cells from 20px to 22px and adds horizontal padding to give the content more room to breathe. This makes the linescore more readable and visually appealing on smaller screens.