### PR TITLE
Fix: Prevent runner card overlap on mobile

### DIFF
--- a/apps/frontend/src/components/BaseballDiamond.vue
+++ b/apps/frontend/src/components/BaseballDiamond.vue
@@ -60,6 +60,13 @@ const emit = defineEmits(['attempt-steal']);
   transform: translate(-50%, -50%); /* Center the card on the coordinates */
 }
 
+@media (max-width: 480px) {
+  .runner-slot {
+    width: 60px;
+    height: 84px;
+  }
+}
+
 .button-slot {
   position: absolute;
   width: 70px;


### PR DESCRIPTION
Adds a media query to `BaseballDiamond.vue` to reduce the size of runner cards on smaller screens, preventing them from overlapping.