### PR TITLE
feat: Skip swing roll screen for bunts

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -634,6 +634,10 @@ function handlePitch(action = null) {
 }
 function handleOffensiveAction(action) {
   console.log('1. GameView: handleOffensiveAction was called with action:', action);
+  if (action === 'bunt') {
+    haveIRolledForSwing.value = true;
+    localStorage.setItem(rollStorageKey, 'true');
+  }
   gameStore.submitAction(gameId, action);
 }
 


### PR DESCRIPTION
When a player chooses to bunt, the outcome is always a roll of 0, making the "roll for swing" screen an unnecessary step that adds no suspense.

This change modifies the `handleOffensiveAction` function in `GameView.vue`. It now checks if the action is a 'bunt' and, if so, immediately sets the `haveIRolledForSwing` flag to `true`. This bypasses the swing roll UI, streamlining the game flow for this specific action.