### PR TITLE
feat: Set pitcher baserunning speed to 'C'

### DIFF
--- a/apps/backend/gameLogic.js
+++ b/apps/backend/gameLogic.js
@@ -8,6 +8,11 @@ function applyOutcome(state, outcome, batter, pitcher, infieldDefense = 0) {
     pitcherOfRecordId: pitcher.card_id 
   };
 
+  // If the batter is a pitcher, set their speed to 'C' (10)
+  if (runnerData.control !== null) {
+    runnerData.speed = 'C';
+  }
+
   const scoreRun = (runnerOnBase) => {
     if (!runnerOnBase) return;
     newState[scoreKey]++;


### PR DESCRIPTION
Pitcher cards do not have a speed rating, which resulted in them having a null speed value when they reached base as a batter.

This change modifies the `applyOutcome` function in `gameLogic.js`. When a batter becomes a baserunner, the logic now checks if the player is a pitcher (by checking for a non-null `control` attribute). If they are, their speed is explicitly set to 'C' for the purpose of baserunning. This ensures game logic that relies on a speed value can function correctly without affecting the pitcher's card data in other contexts.