### PR TITLE
Fix: Correct outs display during at-bat

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -427,8 +427,10 @@ async function resetRolls(gameId) {
   });
 
   const displayGameState = computed(() => {
-    // If we should hide the outcome, construct the "paused" state from the last at-bat.
-    if (shouldHidePlayOutcome.value && gameState.value?.lastCompletedAtBat) {
+    const isBetweenInnings = gameState.value?.isBetweenHalfInningsAway || gameState.value?.isBetweenHalfInningsHome;
+
+    // If we should hide the outcome AND it's between innings, roll back the state.
+    if (shouldHidePlayOutcome.value && isBetweenInnings && gameState.value?.lastCompletedAtBat) {
       return {
         ...gameState.value,
         bases: gameState.value.lastCompletedAtBat.basesBeforePlay,
@@ -438,7 +440,7 @@ async function resetRolls(gameId) {
       };
     }
 
-    // If the game state is loaded, return it.
+    // In ALL other cases (including mid-inning hidden outcomes), return the current state if it exists.
     if (gameState.value) {
       return gameState.value;
     }


### PR DESCRIPTION
The UI was incorrectly rolling back the game state to the state before the previous at-bat when a player had chosen an action but not yet rolled for the swing. This caused the "outs" display to be incorrect.

The `displayGameState` computed property in the `game.js` store is modified to only roll back to the `lastCompletedAtBat` state if the game is between innings. In all other "hidden outcome" scenarios, the current `gameState` is used, ensuring the outs display is accurate for the current at-bat.