### PR TITLE
Fix(game): Prevent batter from being skipped in lineup

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -1850,8 +1850,9 @@ app.post('/api/games/:gameId/submit-decisions', authenticateToken, async (req, r
             await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [defensiveTeam.user_id, gameId]);
         } else {
             newState.currentPlay = null;
-            const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
-            newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
+            // THIS IS THE BUG. The batter is advanced here AND in the next-hitter call.
+            // const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
+            // newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
             await client.query('UPDATE games SET current_turn_user_id = $1 WHERE game_id = $2', [offensiveTeam.user_id, gameId]);
         }
         
@@ -1943,8 +1944,6 @@ app.post('/api/games/:gameId/resolve-throw', authenticateToken, async (req, res)
         }
 
         newState.currentPlay = null;
-        const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
-        newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
 
         if (newState.outs >= 3) {
             newState.isTopInning = !newState.isTopInning;
@@ -2012,8 +2011,6 @@ app.post('/api/games/:gameId/resolve-infield-in-play', authenticateToken, async 
         }
 
         newState.currentPlay = null;
-        const offensiveTeamKey = newState.isTopInning ? 'awayTeam' : 'homeTeam';
-        newState[offensiveTeamKey].battingOrderPosition = (newState[offensiveTeamKey].battingOrderPosition + 1) % 9;
 
         if (newState.outs >= 3) {
             newState.isTopInning = !newState.isTopInning;


### PR DESCRIPTION
Resolves a bug where the batting order position was being incremented in multiple API endpoints, causing batters to be skipped occasionally. This was most noticeable when a pitcher was due up after a complex play.

The `battingOrderPosition` was being advanced in the following endpoints in addition to the correct `next-hitter` endpoint:
- `/api/games/:gameId/submit-decisions`
- `/api/games/:gameId/resolve-throw`
- `/api/games/:gameId/resolve-infield-in-play`

This change removes the redundant increments from these endpoints, ensuring that the `next-hitter` endpoint is the single source of truth for advancing the batter. This centralizes the logic and prevents the double-increment bug.