### PR TITLE
feat: Synchronize score update message with swing result

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -182,7 +182,6 @@ const haveIRolledForSwing = ref(JSON.parse(localStorage.getItem(rollStorageKey))
 
 
 const scoreChangeMessage = ref('');
-const scoreUpdateVisible = ref(false);
 
 // in GameView.vue
 watch([() => gameStore.gameState?.awayScore, () => gameStore.gameState?.homeScore], ([newAwayScore, newHomeScore], [oldAwayScore, oldHomeScore]) => {
@@ -214,10 +213,9 @@ const runScoredOnPlay = computed(() => {
   return lastEvent.log_message?.includes('scores!');
 });
 
-watch(runScoredOnPlay, (hasScored) => {
-    if (hasScored) {
-        scoreUpdateVisible.value = true;
-    }
+const scoreUpdateVisible = computed(() => {
+  const swingIsVisible = isSwingResultVisible.value || (amIDisplayOffensivePlayer.value && haveIRolledForSwing.value);
+  return runScoredOnPlay.value && swingIsVisible;
 });
 
 // in GameView.vue


### PR DESCRIPTION
The score update message was previously displayed as soon as the score changed in the game state, which could happen before the user saw the result of the at-bat.

This change modifies the visibility logic to ensure the score update message only appears at the same time as the swing result is revealed to the player.

- Replaced the `scoreUpdateVisible` ref with a computed property.
- The new computed property checks if a run was scored on the play and if the swing result is currently visible to the user.
- This ensures the score update message is perfectly synchronized with the at-bat outcome reveal, improving the user experience.