### PR TITLE
This commit updates the 'Open Games to Join' list to display the game…

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -858,8 +858,15 @@ app.get('/api/rosters/:rosterId', authenticateToken, async (req, res) => {
 app.get('/api/games/open', authenticateToken, async (req, res) => {
   try {
     const openGamesQuery = await pool.query(
-      `SELECT g.game_id, t.city, t.name, t.display_format, u.user_id as host_user_id
+      `SELECT
+         g.game_id,
+         t.city,
+         t.name,
+         t.display_format,
+         u.user_id as host_user_id,
+         COALESCE(s.series_type, 'exhibition') as series_type
        FROM games g 
+       LEFT JOIN series s ON g.series_id = s.id
        JOIN game_participants gp ON g.game_id = gp.game_id
        JOIN users u ON gp.user_id = u.user_id
        JOIN teams t ON u.team_id = t.team_id

--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -23,6 +23,18 @@ const gamesToJoin = computed(() => {
     return authStore.openGames.filter(game => game.host_user_id !== authStore.user.userId);
 });
 
+function getGameTypeName(seriesType) {
+  switch (seriesType) {
+    case 'regular_season':
+      return 'Regular Season Series';
+    case 'playoff':
+      return 'Playoff Series';
+    case 'exhibition':
+    default:
+      return 'Exhibition';
+  }
+}
+
 function handleCreateGame() {
   if (authStore.myRoster) {
     // Pass the selected series type to the store action
@@ -103,7 +115,7 @@ onUnmounted(() => {
          <ul v-if="authStore.openGames.length > 0" class="game-list">
          <!-- in DashboardView.vue template -->
 <li v-for="game in gamesToJoin" :key="game.game_id">
-  <span>Game vs. {{ game.full_display_name }}</span>
+  <span>{{ getGameTypeName(game.series_type) }} vs. {{ game.full_display_name }}</span>
   <button @click="handleJoinGame(game.game_id)" :disabled="!authStore.myRoster">Join</button>
 </li>
         </ul>


### PR DESCRIPTION
… type (Exhibition, Regular Season Series, or Playoff Series) instead of a generic 'Game' label.

Backend:
- The `/api/games/open` endpoint in `server.js` has been updated.
- The SQL query now performs a `LEFT JOIN` on the `series` table to fetch the `series_type`.
- `COALESCE` is used to default the `series_type` to 'exhibition' for games that are not part of a series, ensuring the frontend always receives a valid type.

Frontend:
- A `getGameTypeName` helper function has been added to `DashboardView.vue` to convert the `series_type` from the API into a user-friendly string.
- The template has been updated to use this new function, dynamically displaying the correct game type for each open game.