### PR TITLE
fix(backend): Correct typo in next-hitter endpoint

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -1612,7 +1612,7 @@ app.post('/api/games/:gameId/next-hitter', authenticateToken, async (req, res) =
         teamToAdvance = 'homeTeam';
       } else {
         // Not an inning change, so advance the current offensive team.
-        teamToAdvance = newState.isTopInning ? 'awayTeam' : 'homeTeam';z
+        teamToAdvance = newState.isTopInning ? 'awayTeam' : 'homeTeam';
       }
       newState[teamToAdvance].battingOrderPosition = (newState[teamToAdvance].battingOrderPosition + 1) % 9;
 


### PR DESCRIPTION
A stray 'z' character was causing a ReferenceError, which made the /api/games/:gameId/next-hitter endpoint crash.

This prevented the game from advancing when a user clicked "Next Hitter" after a play.

This commit removes the typo, resolving the error.