### PR TITLE
fix: Prevent crash on game load when lineup is missing

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -479,7 +479,7 @@ watch(() => atBatToDisplay.value?.pitcherAction, (newAction) => {
 });
 
 const nextBatterInLineup = computed(() => {
-  if (!gameStore.gameState || !gameStore.lineups) return null;
+  if (!gameStore.gameState || !gameStore.lineups?.home || !gameStore.lineups?.away) return null;
 
   const isTop = gameStore.gameState.isTopInning;
   const offensiveTeamState = isTop ? gameStore.gameState.awayTeam : gameStore.gameState.homeTeam;


### PR DESCRIPTION
The `nextBatterInLineup` computed property in `GameView.vue` was causing a TypeError when one of the team's lineups was not yet set. This occurred because the code attempted to access properties on a null object.

This change adds a more robust null check to the computed property, ensuring that `gameStore.lineups.home` and `gameStore.lineups.away` are both populated before attempting to access their properties. This prevents the crash and allows the 'Loading game...' screen to be displayed correctly.