### PR TITLE
fix(frontend): Correct UI state on third out

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -463,6 +463,10 @@ async function resetRolls(gameId) {
           outs: rollbackSource.outsBeforePlay,
           homeScore: rollbackSource.homeScoreBeforePlay,
           awayScore: rollbackSource.awayScoreBeforePlay,
+          // When rolling back a third out, we must also reset the between-innings flags
+          // to prevent the UI from changing (e.g., linescore color) before the outcome is shown.
+          isBetweenHalfInningsAway: false,
+          isBetweenHalfInningsHome: false,
         };
       }
     }


### PR DESCRIPTION
This commit resolves several UI inconsistencies that occurred when a third out was recorded, particularly when the user was waiting to see the outcome of the play.

The following issues have been addressed:
- The outs display, score color, and total runs no longer update prematurely before the outcome is revealed.
- The linescore no longer shows a '0' for the upcoming half-inning before the "Next Hitter" button is clicked.
- The total runs in the linescore now remain consistent with the visible per-inning scores during a state rollback.

The key changes are:
- In `game.js`, the `displayGameState` computed property now correctly resets the `isBetweenHalfInnings` flags when rolling back the state. This prevents the UI from partially updating before the outcome is shown.
- In `Linescore.vue`, the total runs are now calculated by summing the visible per-inning scores, ensuring consistency. The logic has also been updated to prevent adding a score for an inning that has not yet started.