### PR TITLE
feat(frontend): Filter and rename point sets in Roster Builder

### DIFF
--- a/apps/frontend/src/views/RosterBuilderView.vue
+++ b/apps/frontend/src/views/RosterBuilderView.vue
@@ -19,6 +19,18 @@ const roster = ref({
 });
 
 // --- COMPUTED PROPERTIES ---
+const filteredPointSets = computed(() => {
+  const allowedNames = ["Original Pts", "Upcoming Season", "8/4/25 Season"];
+  return authStore.pointSets
+    .filter(set => allowedNames.includes(set.name))
+    .map(set => {
+      if (set.name === "8/4/25 Season") {
+        return { ...set, name: "Current Season" };
+      }
+      return set;
+    });
+});
+
 const allPlayersOnRoster = computed(() => [
     ...Object.values(roster.value.lineup).filter(p => p),
     ...roster.value.pitchingStaff,
@@ -295,7 +307,7 @@ onMounted(async () => {
         <h2>Available Players</h2>
         <div class="filters">
           <select v-model="authStore.selectedPointSetId" title="Select Point Set">
-            <option v-for="set in authStore.pointSets" :key="set.point_set_id" :value="set.point_set_id">
+            <option v-for="set in filteredPointSets" :key="set.point_set_id" :value="set.point_set_id">
               {{ set.name }}
             </option>
           </select>


### PR DESCRIPTION
Implements a change to the RosterBuilderView to only display a curated list of point sets in the dropdown menu.

- A new computed property, `filteredPointSets`, is added to `RosterBuilderView.vue`.
- This property filters the point sets to show only "Original Pts", "Upcoming Season", and "8/4/25 Season".
- It also renames "8/4/25 Season" to "Current Season" for display in the UI.
- The template is updated to use this new computed property, ensuring the user only sees the intended options.