### PR TITLE
Fix: Preserve opposing pitcher in state on substitution

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -733,8 +733,10 @@ app.post('/api/games/:gameId/substitute', authenticateToken, async (req, res) =>
         newState.currentAtBat.batter = playerInCard;
         // Check if the player being pinch-hit for is actually the pitcher.
         if (playerOutCard.control !== null) {
-             newState.currentAtBat.pitcher = null; // Pitcher is removed from the field.
-             // newState.awaitingPitcherSelection = true; // A new pitcher must be selected.
+             // The pitcher has been removed from the batting lineup.
+             // The opposing team's pitcher (in currentAtBat) is unaffected.
+             // A new pitcher will be required later when this team takes the field.
+             // newState.awaitingPitcherSelection = true;
         }
     } else if (newState.currentAtBat.pitcher && newState.currentAtBat.pitcher.card_id === playerOutId) {
         wasReliefPitcher = true;


### PR DESCRIPTION
When a pinch hitter would come in for a pitcher, the logic was incorrectly nullifying the `currentAtBat.pitcher` object.

This was based on a faulty assumption that the pitcher being removed from the batting order was the same as the active pitcher on the field.

This change removes the incorrect state mutation, ensuring that the opposing team's pitcher is preserved in the `currentAtBat` object after a substitution, which prevents the "PitcherTBD" bug from appearing on the frontend.