### PR TITLE
When a substitution results in the "Awaiting Pitcher" state, the mess…

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -898,7 +898,7 @@ onUnmounted(() => {
         <!-- Actions (for layout purposes) -->
         <div class="actions-container">
             <!-- PITCHER SELECTION STATE -->
-            <div v-if="gameStore.gameState?.awaitingPitcherSelection" class="waiting-text">
+            <div v-if="gameStore.gameState?.awaitingPitcherSelection && amIDisplayDefensivePlayer" class="waiting-text">
                 <h3>Awaiting Pitcher</h3>
                 <p>You must substitute in a new pitcher to continue.</p>
             </div>


### PR DESCRIPTION
…age was previously displayed to both players, incorrectly blocking the offensive player from making their move.

This commit refines the conditional logic in `GameView.vue`. The `v-if` directive for the "Awaiting Pitcher" message now includes a check for `amIDisplayDefensivePlayer`. This ensures that only the player who needs to select a new pitcher sees the prompt, allowing the offensive player to set their actions as normal.