### PR TITLE
Fix: Prevent lineup row resizing on substitution mode toggle

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -1023,10 +1023,12 @@ onUnmounted(() => {
                   }"
                   :style="playerToSubOut && spot.player && playerToSubOut.player.card_id === spot.player.card_id ? { backgroundColor: leftPanelData.colors.primary, color: getContrastingTextColor(leftPanelData.colors.primary) } : {}"
                   class="lineup-item">
-                  <span v-if="isSubModeActive && leftPanelData.isMyTeam && (!playerToSubOut || playerToSubOut.player.card_id === spot.player.card_id)"
-                        @click.stop="selectPlayerToSubOut(spot.player, spot.position)"
+                  <span @click.stop="selectPlayerToSubOut(spot.player, spot.position)"
                         class="sub-icon"
-                        :class="{ 'active': playerToSubOut?.player.card_id === spot.player.card_id }">
+                        :class="{
+                            'visible': isSubModeActive && leftPanelData.isMyTeam && (!playerToSubOut || playerToSubOut.player.card_id === spot.player.card_id),
+                            'active': playerToSubOut?.player.card_id === spot.player.card_id
+                        }">
                       ⇄
                   </span>
                   <span @click="selectedCard = spot.player">{{ index + 1 }}. {{ spot.player.displayName }} ({{ spot.position }})</span>
@@ -1034,10 +1036,12 @@ onUnmounted(() => {
           </ol>
           <div class="pitcher-info" :class="{'is-sub-target': playerToSubOut?.player.card_id === leftPanelData.pitcher?.card_id}" :style="playerToSubOut && leftPanelData.pitcher && playerToSubOut.player.card_id === leftPanelData.pitcher.card_id ? { backgroundColor: leftPanelData.colors.primary, color: getContrastingTextColor(leftPanelData.colors.primary) } : {}">
             <hr />
-            <span v-if="isSubModeActive && leftPanelData.isMyTeam && leftPanelData.pitcher && (!playerToSubOut || playerToSubOut.player.card_id === leftPanelData.pitcher.card_id)"
-                  @click.stop="selectPlayerToSubOut(leftPanelData.pitcher, 'P')"
+            <span @click.stop="selectPlayerToSubOut(leftPanelData.pitcher, 'P')"
                   class="sub-icon"
-                  :class="{ 'active': playerToSubOut?.player.card_id === leftPanelData.pitcher.card_id }">
+                  :class="{
+                      'visible': isSubModeActive && leftPanelData.isMyTeam && leftPanelData.pitcher && (!playerToSubOut || playerToSubOut.player.card_id === leftPanelData.pitcher.card_id),
+                      'active': playerToSubOut?.player.card_id === leftPanelData.pitcher.card_id
+                  }">
                 ⇄
             </span>
             <span @click="selectedCard = leftPanelData.pitcher">
@@ -1050,9 +1054,9 @@ onUnmounted(() => {
               <hr /><strong :style="{ color: leftPanelData.colors.primary }">Bullpen:</strong>
               <ul>
                   <li v-for="p in leftPanelData.bullpen" :key="p.card_id" class="lineup-item" :class="{'is-sub-in-candidate': isSubModeActive && playerToSubOut && !usedPlayerIds.has(p.card_id)}">
-                      <span v-if="isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && !usedPlayerIds.has(p.card_id)"
-                            @click.stop="handleSubstitution(p)"
-                            class="sub-icon">
+                      <span @click.stop="handleSubstitution(p)"
+                            class="sub-icon"
+                            :class="{ 'visible': isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && !usedPlayerIds.has(p.card_id) }">
                           ⇄
                       </span>
                       <span @click="selectedCard = p" :class="{'is-used': usedPlayerIds.has(p.card_id)}">{{ p.displayName }} ({{p.ip}} IP)</span>
@@ -1063,9 +1067,9 @@ onUnmounted(() => {
               <hr /><strong :style="{ color: leftPanelData.colors.primary }">Bench:</strong>
               <ul>
                   <li v-for="p in leftPanelData.bench" :key="p.card_id" class="lineup-item" :class="{'is-sub-in-candidate': isSubModeActive && playerToSubOut && !usedPlayerIds.has(p.card_id)}">
-                      <span v-if="isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && !usedPlayerIds.has(p.card_id)"
-                            @click.stop="handleSubstitution(p)"
-                            class="sub-icon">
+                      <span @click.stop="handleSubstitution(p)"
+                            class="sub-icon"
+                            :class="{ 'visible': isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && !usedPlayerIds.has(p.card_id) }">
                           ⇄
                       </span>
                       <span @click="selectedCard = p" :class="{'is-used': usedPlayerIds.has(p.card_id)}">{{ p.displayName }} ({{p.displayPosition}})</span>
@@ -1342,8 +1346,12 @@ onUnmounted(() => {
   justify-content: center;
   width: 24px;
   height: 24px;
+  visibility: hidden; /* Hide by default, but reserve space */
 }
-.sub-icon:hover:not(.active) {
+.sub-icon.visible, .sub-icon.active {
+  visibility: visible; /* Make visible when conditions are met */
+}
+.sub-icon.visible:hover:not(.active) {
   background-color: rgba(0,0,0,0.05);
 }
 .sub-icon.active {

--- a/jules-scratch/verification/verify_lineup_panel.py
+++ b/jules-scratch/verification/verify_lineup_panel.py
@@ -1,0 +1,73 @@
+from playwright.sync_api import sync_playwright, expect
+import time
+
+def run(playwright):
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # Use a unique email for registration
+    unique_email = f"testuser_{int(time.time())}@example.com"
+
+    # Register a new user
+    page.goto("http://localhost:5173/register")
+    page.get_by_label("Email").fill(unique_email)
+    page.get_by_label("Password").fill("password")
+    page.get_by_label("Owner First Name").fill("Test")
+    page.get_by_label("Owner Last Name").fill("User")
+
+    # Select the first available team
+    team_select = page.get_by_label("Select Your Team")
+    # Wait for the options to be populated by the API call by checking the second option
+    expect(team_select.locator("option").nth(1)).to_be_enabled(timeout=10000)
+    team_select.select_option(index=1)
+
+    page.get_by_role("button", name="Create Account & Claim Team").click()
+
+    # Wait for navigation to the dashboard
+    expect(page).to_have_url("http://localhost:5173/dashboard", timeout=10000)
+
+    # Create a roster
+    page.get_by_role("button", name="Create Your Roster").click()
+    expect(page).to_have_url("http://localhost:5173/roster-builder", timeout=10000)
+    page.get_by_role("button", name="Save Roster").click()
+
+    # Wait for navigation back to the dashboard
+    expect(page).to_have_url("http://localhost:5173/dashboard", timeout=10000)
+
+    # Create a new game
+    page.get_by_role("button", name="+ Create New Game").click()
+
+    # Wait for navigation to the game setup page and get the game ID
+    expect(page).to_have_url(lambda url: "/game/" in url and "/setup" in url, timeout=10000)
+    game_id = page.url.split("/")[4]
+
+    # Use dev tool to set up game state
+    page.goto(f"http://localhost:5173/dev-tool/{game_id}")
+    page.get_by_role("button", name="Set Game State").click()
+
+    # Navigate to the game view
+    page.goto(f"http://localhost:5173/game/{game_id}")
+
+    # Wait for the lineup panel to be visible
+    lineup_panel = page.locator(".lineup-panel").first
+    expect(lineup_panel).to_be_visible(timeout=10000)
+
+    # Activate substitution mode
+    sub_toggle_button = page.locator(".lineup-header .sub-icon").first
+    expect(sub_toggle_button).to_be_visible()
+    sub_toggle_button.click()
+
+    # Take a screenshot with substitution mode active
+    page.screenshot(path="jules-scratch/verification/lineup_sub_mode_active.png")
+
+    # Deactivate substitution mode
+    sub_toggle_button.click()
+
+    # Take a screenshot with substitution mode inactive
+    page.screenshot(path="jules-scratch/verification/lineup_sub_mode_inactive.png")
+
+    browser.close()
+
+with sync_playwright() as playwright:
+    run(playwright)


### PR DESCRIPTION
The substitution icon in the lineup panel was conditionally rendered using `v-if`, which caused the row's dimensions to change when the icon was added to or removed from the DOM. This resulted in a jarring layout shift.

This commit replaces the `v-if` directive with a dynamic class binding that controls the icon's `visibility` property in CSS. The icon now always occupies space in the DOM, but is only made visible when substitution mode is active. This ensures the lineup rows maintain a consistent size, eliminating the layout shift.