### PR TITLE
Refactor third-out display logic to fix multiple UI bugs.

### DIFF
--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -24,8 +24,8 @@ const isGamePage = computed(() => route.name === 'game');
     <div class="nav-center">
       <Linescore v-if="isGamePage && gameStore.gameState && gameStore.gameEvents.length > 0" />
       <OutsDisplay
-        v-if="isGamePage && gameStore.gameState"
-        :outs="gameStore.displayOuts"
+        v-if="isGamePage && gameStore.displayGameState"
+        :outs="gameStore.displayGameState.outs"
       />
     </div>
 


### PR DESCRIPTION
This commit addresses a series of interconnected bugs that occurred during third-out plays, particularly when the pitcher acted second.

The core of the solution involves refactoring the logic that determines when to hide a play's outcome from the user. The previously scattered and fragile implementation was causing race conditions and UI inconsistencies.

Key changes:
- Centralized the outcome-hiding logic into a new `shouldHideCurrentAtBatOutcome` computed property in `GameView.vue`.
- Simplified the `displayGameState` computed property in the `game.js` store to use `currentAtBat` as the single source of truth for state rollbacks, fixing the bug where the outs display would roll back too far.
- Ensured `isBetweenHalfInnings` flags are reset during rollbacks to prevent the linescore color from changing prematurely.
- Corrected the `gameEventsToDisplay` logic to prevent the inning-change message from appearing before the "Next Hitter" button is clicked.
- Added a `showRollForSwingButton` computed property to reliably show the button for the offensive player at the correct time.
- Removed redundant state and watchers from the `game.js` store and `GameView.vue` to simplify the architecture and prevent reactivity errors.