### PR TITLE
feat: Default to Current Season in Roster Builder

### DIFF
--- a/apps/frontend/src/stores/auth.js
+++ b/apps/frontend/src/stores/auth.js
@@ -84,9 +84,14 @@ const myRoster = ref(null);
       if (!response.ok) throw new Error('Failed to fetch point sets');
       const sets = await response.json();
       pointSets.value = sets;
-      // Default to the newest set if one isn't already selected
+      // Default to "Current Season" (i.e., "8/4/25 Season") if available, otherwise newest set.
       if (sets.length > 0 && !selectedPointSetId.value) {
-        selectedPointSetId.value = sets[0].point_set_id;
+        const currentSeasonSet = sets.find(set => set.name === "8/4/25 Season");
+        if (currentSeasonSet) {
+          selectedPointSetId.value = currentSeasonSet.point_set_id;
+        } else {
+          selectedPointSetId.value = sets[0].point_set_id; // Fallback
+        }
       }
     } catch (error) {
       console.error('Failed to fetch point sets:', error);


### PR DESCRIPTION
Updates the Roster Builder to default to the 'Current Season' point set instead of the newest available set.

This change modifies the `fetchPointSets` action in the `auth.js` Pinia store. The logic now actively looks for the point set named '8/4/25 Season' (aliased as 'Current Season' on the frontend) and sets it as the default selection. If this specific set is not found, the application falls back to selecting the first point set in the list, preserving the previous behavior.