### PR TITLE
fix(vue): Resolve race condition in outcome visibility watcher

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -298,8 +298,9 @@ const shouldHideCurrentAtBatOutcome = computed(() => {
 // Watch the new computed property and update the central store state.
 // This is the link that tells the store whether to provide a "rolled-back" game state.
 watch(shouldHideCurrentAtBatOutcome, (newValue) => {
-  // Guard against both the initial load and unmount race conditions.
-  if (!initialLoadComplete.value || !gameStore.gameState) return;
+  // Guard against unmount race conditions where the watcher might fire after
+  // the store has been cleared but before the component is fully gone.
+  if (!gameStore.gameState) return;
   gameStore.setOutcomeHidden(newValue);
 }, { immediate: true });
 


### PR DESCRIPTION
The watcher for 'shouldHideCurrentAtBatOutcome' in GameView.vue included an 'initialLoadComplete' flag in its guard clause.

This created a race condition where the watcher would fire upon the initial data load before the onMounted hook had a chance to set 'initialLoadComplete' to true, causing the watcher's effect to be skipped.

This change removes the unnecessary 'initialLoadComplete' check, relying on the existing '!gameStore.gameState' check to prevent errors during component unmounting. This ensures the outcome visibility is correctly set on initial load.