### PR TITLE
feat: Use city name in substitution log messages

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -698,7 +698,12 @@ app.post('/api/games/:gameId/substitute', authenticateToken, async (req, res) =>
     const playerOutCard = playerOutResult.rows[0];
     
     newState[teamKey].used_player_ids.push(playerOutId);
-    const teamName = teamKey === 'homeTeam' ? 'Home' : 'Away';
+
+    // Get the correct user ID for the team being substituted
+    const teamUserId = newState[teamKey].userId;
+    // Get the team's city for a more descriptive log message
+    const teamResult = await client.query('SELECT city FROM teams WHERE user_id = $1', [teamUserId]);
+    const teamName = teamResult.rows[0]?.city || (teamKey === 'homeTeam' ? 'Home' : 'Away');
 
     let wasPinchRunner = false;
     let wasPinchHitter = false;


### PR DESCRIPTION
Updates the substitution endpoint to fetch and use the team's city name in the game log. This provides a more immersive and descriptive message for players.

The logic correctly identifies the team being substituted by using the `userId` from the game state, rather than the ID of the authenticated user making the request. This prevents incorrect team attribution in scenarios where one user might be controlling both teams.