### PR TITLE
feat: Snapshot rosters at game start to prevent crashes

### DIFF
--- a/apps/backend/migrations/1759857476363_create-game-rosters-table.js
+++ b/apps/backend/migrations/1759857476363_create-game-rosters-table.js
@@ -1,0 +1,28 @@
+exports.up = pgm => {
+  pgm.createTable('game_rosters', {
+    game_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"games"(game_id)',
+      onDelete: 'CASCADE',
+    },
+    user_id: {
+      type: 'integer',
+      notNull: true,
+      references: '"users"(user_id)',
+      onDelete: 'CASCADE',
+    },
+    roster_data: {
+      type: 'jsonb',
+      notNull: true,
+    },
+  });
+
+  pgm.addConstraint('game_rosters', 'game_rosters_pkey', {
+    primaryKey: ['game_id', 'user_id'],
+  });
+};
+
+exports.down = pgm => {
+  pgm.dropTable('game_rosters');
+};

--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -1,6 +1,7 @@
 // server.js - DEFINITIVE FINAL VERSION
+const path = require('path');
 if (process.env.NODE_ENV !== 'production') {
-  require('dotenv').config();
+  require('dotenv').config({ path: path.join(__dirname, '.env') });
 }
 const express = require('express');
 const http = require('http');
@@ -557,6 +558,16 @@ app.post('/api/games/:gameId/lineup', authenticateToken, async (req, res) => {
 
       const homeParticipant = allParticipants.rows.find(p => Number(p.user_id) === Number(homePlayerId));
       const awayParticipant = allParticipants.rows.find(p => Number(p.user_id) !== Number(homePlayerId));
+
+      // --- NEW: Snapshot the rosters for this game ---
+      const homeRosterCardsResult = await client.query(`SELECT * FROM cards_player WHERE card_id = ANY(SELECT card_id FROM roster_cards WHERE roster_id = $1)`, [homeParticipant.roster_id]);
+      const homeRosterData = homeRosterCardsResult.rows;
+      await client.query(`INSERT INTO game_rosters (game_id, user_id, roster_data) VALUES ($1, $2, $3)`, [gameId, homeParticipant.user_id, JSON.stringify(homeRosterData)]);
+
+      const awayRosterCardsResult = await client.query(`SELECT * FROM cards_player WHERE card_id = ANY(SELECT card_id FROM roster_cards WHERE roster_id = $1)`, [awayParticipant.roster_id]);
+      const awayRosterData = awayRosterCardsResult.rows;
+      await client.query(`INSERT INTO game_rosters (game_id, user_id, roster_data) VALUES ($1, $2, $3)`, [gameId, awayParticipant.user_id, JSON.stringify(awayRosterData)]);
+      // --- END NEW ---
       
       await client.query(
         `UPDATE games SET status = 'in_progress', current_turn_user_id = $1 WHERE game_id = $2`,
@@ -1243,8 +1254,8 @@ async function getAndProcessGameData(gameId, dbClient) {
     currentState.state_data.defensiveRatings = defensiveRatings;
 
     for (const p of participantsResult.rows) {
-      const rosterCardsResult = await dbClient.query(`SELECT * FROM cards_player WHERE card_id = ANY(SELECT card_id FROM roster_cards WHERE roster_id = $1)`, [p.roster_id]);
-      const fullRosterCards = rosterCardsResult.rows;
+      const rosterResult = await dbClient.query('SELECT roster_data FROM game_rosters WHERE game_id = $1 AND user_id = $2', [gameId, p.user_id]);
+      const fullRosterCards = rosterResult.rows[0]?.roster_data || [];
       if (p.lineup?.battingOrder) {
         const lineupWithDetails = p.lineup.battingOrder.map(spot => ({ ...spot, player: fullRosterCards.find(c => c.card_id === spot.card_id) }));
         const spCard = fullRosterCards.find(c => c.card_id === p.lineup.startingPitcher);

--- a/jules-scratch/verification/verify_game_load.py
+++ b/jules-scratch/verification/verify_game_load.py
@@ -1,0 +1,120 @@
+import re
+from playwright.sync_api import sync_playwright, expect
+
+def run(playwright):
+    # --- Test Setup ---
+    # Define user credentials and team info
+    user1 = {"email": "user1@test.com", "password": "password123"}
+    user2 = {"email": "user2@test.com", "password": "password123"}
+    team1_name = "Boston True Alrics"
+    team2_name = "Detroit Style Pizzas"
+
+    # Define selectors
+    dashboard_header = "h1:has-text('Your Dashboard')"
+    baseball_diamond = "canvas" # A key element in GameView.vue
+
+    # --- Browser and Page Setup ---
+    browser = playwright.chromium.launch(headless=True)
+    context = browser.new_context()
+    page = context.new_page()
+
+    # --- Helper Functions ---
+    def register(user, team_name):
+        print(f"Registering {user['email']}...")
+        page.goto("http://localhost:5173/register")
+        page.get_by_label("Email").fill(user["email"])
+        page.get_by_label("Password").fill(user["password"])
+        page.get_by_label("First Name").fill("Test")
+        page.get_by_label("Last Name").fill("User")
+        page.get_by_label("Team").select_option(label=team_name)
+        register_button = page.get_by_role("button", name="Register")
+        expect(register_button).to_be_enabled(timeout=10000) # Wait for the button to be clickable
+        register_button.click()
+        expect(page.get_by_text("Registration successful!")).to_be_visible()
+        print(f"Registration successful for {user['email']}.")
+
+    def login(user):
+        print(f"Logging in as {user['email']}...")
+        page.goto("http://localhost:5173/login")
+        page.get_by_label("Email").fill(user["email"])
+        page.get_by_label("Password").fill(user["password"])
+        page.get_by_role("button", name="Login").click()
+        expect(page.locator(dashboard_header)).to_be_visible()
+        print(f"Login successful for {user['email']}.")
+
+    def create_roster():
+        print("Creating roster...")
+        page.get_by_role("link", name="Roster Builder").click()
+        # Select the first 20 players available
+        for i in range(20):
+            page.locator('.player-card-grid .player-card').nth(i).get_by_role('button', name='Add').click()
+        page.get_by_role("button", name="Save Roster").click()
+        expect(page.get_by_text("Roster saved successfully!")).to_be_visible()
+        print("Roster created successfully.")
+        page.get_by_role("link", name="Dashboard").click()
+        expect(page.locator(dashboard_header)).to_be_visible()
+
+    def set_lineup():
+        print("Setting lineup...")
+        page.get_by_role("button", name=re.compile("Set Lineup")).click()
+        expect(page.get_by_text("Set Your Lineup")).to_be_visible()
+        # Select the first available pitcher
+        page.locator('.pitcher-card').first.click()
+        page.get_by_role("button", name="Save Lineup").click()
+        print("Lineup set.")
+
+    # --- Main Test Flow ---
+    try:
+        # 1. Register and set up User 1
+        register(user1, team1_name)
+        login(user1)
+        create_roster()
+
+        # 2. User 1 creates a game
+        print("User 1 creating game...")
+        page.get_by_role("button", name="Create New Game").click()
+        page.get_by_role("button", name="Create Game").click()
+        expect(page.get_by_text("waiting for opponent")).to_be_visible()
+        game_url = page.url
+        print(f"Game created at {game_url}")
+        page.get_by_role("button", name="Logout").click()
+
+        # 3. Register and set up User 2
+        register(user2, team2_name)
+        login(user2)
+        create_roster()
+
+        # 4. User 2 joins the game
+        print("User 2 joining game...")
+        page.get_by_role("button", name=f"vs {team1_name}").click()
+        expect(page.get_by_text("Game Setup")).to_be_visible()
+        print("User 2 joined successfully.")
+
+        # 5. User 2 sets up the game and their lineup
+        page.get_by_role("button", name=team2_name).click() # Choose self as home team
+        page.get_by_role("button", name="Confirm Setup & Proceed to Lineups").click()
+        set_lineup()
+        expect(page.get_by_text("Waiting for opponent to set lineup...")).to_be_visible()
+        page.get_by_role("button", name="Logout").click()
+
+        # 6. User 1 logs back in and sets their lineup, starting the game
+        login(user1)
+        page.goto(game_url) # Go directly to the game
+        set_lineup()
+
+        # 7. Verification
+        print("Verifying game has loaded...")
+        # The ultimate verification: does the game view render?
+        expect(page.locator(baseball_diamond)).to_be_visible(timeout=10000)
+        print("Game view loaded successfully!")
+
+        # Take a screenshot for visual confirmation
+        page.screenshot(path="jules-scratch/verification/verification.png")
+        print("Screenshot captured.")
+
+    finally:
+        browser.close()
+
+if __name__ == "__main__":
+    with sync_playwright() as playwright:
+        run(playwright)


### PR DESCRIPTION
This change introduces a roster snapshotting mechanism to prevent game-loading crashes when a player's roster is modified after a game has started.

Previously, the application fetched the latest version of a player's roster every time a game was loaded. If a player from the original lineup had been removed from the roster in the roster builder, the application would crash because it couldn't find the player's data.

This commit addresses the issue by:
1.  Creating a new `game_rosters` table to store a complete JSON snapshot of each player's roster at the beginning of a game.
2.  Modifying the lineup submission endpoint (`/api/games/:gameId/lineup`) to save the roster snapshots when the game status becomes `in_progress`.
3.  Updating the game data retrieval logic (`getAndProcessGameData`) to pull player information from the `game_rosters` snapshot instead of the live roster tables.

This ensures that each game is a self-contained entity, immune to later roster modifications, providing a more stable and reliable user experience.