### PR TITLE
fix(frontend): Resolve recursive update loop in GameView

### DIFF
--- a/apps/frontend/src/stores/game.js
+++ b/apps/frontend/src/stores/game.js
@@ -421,8 +421,8 @@ async function resetRolls(gameId) {
   });
 
   const isBetweenHalfInnings = computed(() => {
-    if (!displayGameState.value) return false;
-    return displayGameState.value.isBetweenHalfInningsAway || displayGameState.value.isBetweenHalfInningsHome;
+    if (!gameState.value) return false;
+    return gameState.value.isBetweenHalfInningsAway || gameState.value.isBetweenHalfInningsHome;
   });
 
   const displayGameState = computed(() => {

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -277,7 +277,7 @@ const shouldHideCurrentAtBatOutcome = computed(() => {
   if (!atBatIsResolved && !gameStore.opponentReadyForNext) return false;
 
   // Scenario 1: Offensive player has resolved the at-bat but hasn't "rolled" to see the result.
-  const isOffensivePlayerWaitingToRoll = amIOffensivePlayer.value && !haveIRolledForSwing.value;
+  const isOffensivePlayerWaitingToRoll = amIDisplayOffensivePlayer.value && !haveIRolledForSwing.value;
   if (isOffensivePlayerWaitingToRoll) {
     return true;
   }


### PR DESCRIPTION
This commit fixes a "Maximum recursive updates" error that occurred in GameView.vue when trying to use `amIDisplayOffensivePlayer` in the `shouldHideCurrentAtBatOutcome` computed property.

The root cause was a circular dependency in the Pinia store. The `isBetweenHalfInnings` computed property was dependent on `displayGameState`, which in turn was modified based on `shouldHideCurrentAtBatOutcome`. This created a reactive loop.

The fix resolves this by modifying `isBetweenHalfInnings` in `stores/game.js` to read directly from the raw `gameState.value` instead of the derived `displayGameState.value`. This breaks the circular dependency and allows the intended logic in `GameView.vue` to function correctly without causing a recursive update error.