### PR TITLE
Fix: Allow pinch running/hitting for Designated Hitters (DH)

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -134,6 +134,13 @@ function selectPlayerToSubOut(player, position, index = null, source = 'lineup')
     }
 
     if (isPlayerOnField) {
+      if (playerToSubOut.value?.position === 'DH' || position === 'DH') {
+          alert('The DH cannot change positions defensively.');
+          isSubModeActive.value = false;
+          playerToSubOut.value = null;
+          gameStore.playerSelectedForSwap = null;
+          return;
+      }
       gameStore.swapPlayerPositions(gameId, gameStore.playerSelectedForSwap.card_id, player.card_id);
     } else {
       handleSubstitution(player);
@@ -2430,7 +2437,7 @@ function handleVisibilityChange() {
                   <span @click.stop="selectPlayerToSubOut(spot.player, spot.position, index, 'lineup')"
                         class="sub-icon"
                         :class="{
-                            'visible': isSubModeActive && leftPanelData.isMyTeam && spot.position !== 'DH' && isPlayerSubEligible(spot.player),
+                            'visible': isSubModeActive && leftPanelData.isMyTeam && isPlayerSubEligible(spot.player),
                             'active': playerToSubOut?.source === 'lineup' && playerToSubOut?.index === index
                         }">
                       ⇄

--- a/apps/frontend/src/views/GameViewOld.vue
+++ b/apps/frontend/src/views/GameViewOld.vue
@@ -132,6 +132,13 @@ function selectPlayerToSubOut(player, position, index = null, source = 'lineup')
     }
 
     if (isPlayerOnField) {
+      if (playerToSubOut.value?.position === 'DH' || position === 'DH') {
+          alert('The DH cannot change positions defensively.');
+          isSubModeActive.value = false;
+          playerToSubOut.value = null;
+          gameStore.playerSelectedForSwap = null;
+          return;
+      }
       // It's a position swap
       gameStore.swapPlayerPositions(gameId, gameStore.playerSelectedForSwap.card_id, player.card_id);
     } else {
@@ -2512,7 +2519,7 @@ function handleVisibilityChange() {
                   <span @click.stop="selectPlayerToSubOut(spot.player, spot.position, index, 'lineup')"
                         class="sub-icon"
                         :class="{
-                            'visible': isSubModeActive && leftPanelData.isMyTeam && spot.position !== 'DH' && isPlayerSubEligible(spot.player),
+                            'visible': isSubModeActive && leftPanelData.isMyTeam && isPlayerSubEligible(spot.player),
                             'active': playerToSubOut?.source === 'lineup' && playerToSubOut?.index === index
                         }">
                       ⇄


### PR DESCRIPTION
Fixed the inability to pinch hit or pinch run for the designated hitter (DH).

The frontend was incorrectly hiding the substitution button if a player's position was "DH". I removed the `spot.position !== 'DH'` condition, allowing the icon to render and users to initiate a substitution for their DH. I also added defensive checks into `selectPlayerToSubOut` in both `GameView.vue` and `GameViewOld.vue` that trigger an alert and block position-swapping when trying to swap a DH position with an active defensive position, preserving the DH integrity while allowing bench substitutions.

Tested with `npm test` internally.

---
*PR created automatically by Jules for task [9855168883631857572](https://jules.google.com/task/9855168883631857572) started by @dc421*