### PR TITLE
Update navbar highlighting for League and Classic

### DIFF
--- a/apps/backend/routes/classic.js
+++ b/apps/backend/routes/classic.js
@@ -183,7 +183,19 @@ router.get('/state', authenticateToken, async (req, res) => {
             rosters = Object.values(rosterMap);
         }
 
+        // 4. Check for uncompleted Classic games to determine active state for navbar
+        const activeQuery = `
+            SELECT 1
+            FROM series_results
+            WHERE winning_score IS NULL
+            AND style = 'Classic'
+            LIMIT 1
+        `;
+        const activeResult = await pool.query(activeQuery);
+        const isActive = activeResult.rows.length > 0;
+
         res.json({
+            isActive,
             classic: {
                 id: classic.id,
                 name: classic.name,

--- a/apps/frontend/src/components/GlobalNav.vue
+++ b/apps/frontend/src/components/GlobalNav.vue
@@ -69,7 +69,7 @@ onMounted(async () => {
 
         if (classicRes.ok) {
             const data = await classicRes.json();
-            gameStore.isClassicActive = data.classic?.is_active || false;
+            gameStore.isClassicActive = data.isActive ?? (data.classic?.is_active || false);
         }
 
         if (leagueRes.ok) {
@@ -375,7 +375,7 @@ onMounted(async () => {
   }
 }
 
-.active-draft {
+.active-draft, .active-league {
   color: #ffc107 !important;
   font-weight: bold;
   border: 2px solid #ffc107;
@@ -383,7 +383,7 @@ onMounted(async () => {
   border-radius: 4px;
 }
 
-.active-classic, .active-league {
+.active-classic {
   color: #20c997 !important;
   font-weight: bold;
   border: 2px solid #20c997;


### PR DESCRIPTION
1. Added `.active-league` to the `.active-draft` CSS class block so it displays yellow.
2. Updated `apps/backend/routes/classic.js` to look for incomplete Classic series_results.
3. Passed the new logic via `isActive` to the frontend, which handles the `gameStore.isClassicActive` properly, making sure it ignores stale active flags in the `classics` table.

---
*PR created automatically by Jules for task [4139738357762611278](https://jules.google.com/task/4139738357762611278) started by @dc421*