### PR TITLE
Fix Classic series end condition

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -769,7 +769,7 @@ async function handleSeriesProgression(gameId, client, finalState) {
 
     // 4. Check if the series is over
     let isSeriesOver = false;
-    if (series_type === 'playoff' && (home_wins >= 4 || away_wins >= 4)) {
+    if ((series_type === 'playoff' || series_type === 'classic') && (home_wins >= 4 || away_wins >= 4)) {
         isSeriesOver = true;
     }
     if (series_type === 'regular_season' && game_in_series >= 7) {


### PR DESCRIPTION
Fixes an issue where a Classic series would improperly continue beyond 4 wins to generate a Game 8, because `handleSeriesProgression` was only checking for the `'playoff'` series type. `'classic'` is now evaluated with `'playoff'` to end accurately after 4 wins.

---
*PR created automatically by Jules for task [17541975812601040769](https://jules.google.com/task/17541975812601040769) started by @dc421*