### PR TITLE
Fix premature pitch reveal in simultaneous mode

### DIFF
--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -18,8 +18,8 @@ const { isSwingResultVisible, isStealResultVisible, nextGameId } = storeToRefs(g
 const authStore = useAuthStore();
 const gameId = route.params.id;
 const initialLoadComplete = ref(false);
-const seenResultStorageKey = `showdown-game-${gameId}-swing-result-seen`;
-const hasSeenResult = ref(JSON.parse(localStorage.getItem(seenResultStorageKey)) || false);
+const seenResultStorageKey = computed(() => `showdown-game-${gameId}-turn-${gameStore.gameState?.turn_number || 0}-swing-result-seen`);
+const hasSeenResult = ref(false);
 const seriesUpdateMessage = ref('');
 const offensiveDPResultVisible = ref(false);
 const defensiveDPRollClicked = ref(false);
@@ -1419,8 +1419,10 @@ watch([bothPlayersSetAction, () => atBatToDisplay.value], ([isRevealing]) => {
     revealTimeout = setTimeout(() => {
       gameStore.setIsSwingResultVisible(true);
       hasSeenResult.value = true;
-      localStorage.setItem(seenResultStorageKey, 'true');
+      localStorage.setItem(seenResultStorageKey.value, 'true');
     }, 900);
+  } else if (atBatToDisplay.value?.pitcherAction !== 'intentional_walk') {
+    simulPitchVisible.value = false;
   }
 }, { immediate: true });
 
@@ -1819,7 +1821,7 @@ function handleNextHitter() {
   // SIMUL: Reset pitch visibility for next at-bat
   simulPitchVisible.value = false;
   hasSeenResult.value = false;
-  localStorage.removeItem(seenResultStorageKey);
+  localStorage.removeItem(seenResultStorageKey.value);
   defensiveThrowRollClicked.value = false;
   defensiveDPRollClicked.value = false;
   offensiveDPResultVisible.value = false;
@@ -2124,12 +2126,11 @@ const delayInningChange = computed(() => {
 onMounted(async () => {
   await gameStore.fetchGame(gameId);
 
-  const storedResultSeen = JSON.parse(localStorage.getItem(seenResultStorageKey)) || false;
-  if (storedResultSeen) {
+  hasSeenResult.value = JSON.parse(localStorage.getItem(seenResultStorageKey.value)) || false;
+  if (hasSeenResult.value) {
       gameStore.setIsSwingResultVisible(true);
       // SIMUL: Also restore pitch visibility
       simulPitchVisible.value = true;
-      hasSeenResult.value = true;
   }
 
   initialLoadComplete.value = true;
@@ -2250,6 +2251,7 @@ function handleVisibilityChange() {
           </div>
           <!-- SIMUL: Pitch box only shows after simulPitchVisible is set (when both players have acted) -->
           <div v-if="atBatToDisplay.pitchRollResult && simulPitchVisible &&
+            (bothPlayersSetAction || atBatToDisplay.pitcherAction === 'intentional_walk') &&
             !(isDoubleStealResultAvailable.value && !(gameStore.gameState.currentAtBat.pitcherAction && !gameStore.gameState.currentAtBat.batterAction)) &&
             !isStealAttemptInProgress && !(showAutoThrowResult && !atBatToDisplay.swingRollResult)" :class="pitchResultClasses" :style="{ backgroundColor: hexToRgba(pitcherTeamColors.primary), borderColor: hexToRgba(pitcherTeamColors.secondary), color: pitcherResultTextColor }">
               Pitch: <strong>{{ atBatToDisplay.pitchRollResult.roll === 'IBB' ? 'IBB' : atBatToDisplay.pitchRollResult.roll }}</strong>


### PR DESCRIPTION
Fixes a vulnerability in `GameView.vue` where the offensive player could sometimes see the defensive pitch roll before submitting their own action.

### Changes
* **Fix localStorage Leak**: `seenResultStorageKey` previously did not include the `turn_number`, meaning refreshing the page could instantly satisfy `storedResultSeen` and display the pitch before the player had submitted a swing. It now tracks `turn_number` to uniquely scope the local storage variable.
* **Hardcode UI Condition**: Added a strict requirement that `bothPlayersSetAction` or `atBatToDisplay.pitcherAction === 'intentional_walk'` must be true for the pitch roll box to be rendered in the template.
* **Watcher Safeguard**: explicitly forces `simulPitchVisible.value = false` if `bothPlayersSetAction` goes to false (e.g. at the start of a new turn or during async rollbacks) preventing lingering views.

---
*PR created automatically by Jules for task [12417749732080685204](https://jules.google.com/task/12417749732080685204) started by @dc421*