### PR TITLE
Fix Enter Series Result modal team names and backend payload

### DIFF
--- a/apps/backend/routes/league.js
+++ b/apps/backend/routes/league.js
@@ -434,6 +434,7 @@ router.get('/season-summary', authenticateToken, async (req, res) => {
                         winning_team_id: r.winning_team_id,
                         losing_team_id: r.losing_team_id,
                         winner: r.winning_team_name,
+                        loser: r.losing_team_name,
                         winner_name: winner.displayName,
                         loser_name: loser.displayName,
 
@@ -522,9 +523,9 @@ router.get('/matrix', authenticateToken, async (req, res) => {
 
 // SUBMIT/UPDATE RESULT (POST)
 router.post('/result', authenticateToken, async (req, res) => {
-    const { id, winning_score, losing_score, winner_id, mva, lvsc } = req.body;
+    const { id, team1_score, team2_score, team1_id, team2_id, mva, lvsc } = req.body;
 
-    if (!id || winning_score === undefined || losing_score === undefined || !winner_id) {
+    if (!id || team1_score === undefined || team2_score === undefined || !team1_id || !team2_id) {
         return res.status(400).json({ message: 'Missing required fields.' });
     }
 
@@ -540,19 +541,33 @@ router.post('/result', authenticateToken, async (req, res) => {
 
         const original = originalRes.rows[0];
 
-        let newWinningId = winner_id;
-        let newLosingId = (original.winning_team_id === winner_id) ? original.losing_team_id : original.winning_team_id;
-
+        // Determine winner and loser based on scores
+        let newWinningId, newLosingId, winning_score, losing_score;
         let newWinningName, newLosingName;
-        if (winner_id === original.winning_team_id) {
+
+        if (team1_score >= team2_score) {
+            newWinningId = team1_id;
+            newLosingId = team2_id;
+            winning_score = team1_score;
+            losing_score = team2_score;
+        } else {
+            newWinningId = team2_id;
+            newLosingId = team1_id;
+            winning_score = team2_score;
+            losing_score = team1_score;
+        }
+
+        // Figure out names using the original record
+        if (newWinningId === original.winning_team_id) {
             newWinningName = original.winning_team_name;
             newLosingName = original.losing_team_name;
-            newLosingId = original.losing_team_id;
-        } else {
-            // Swap
+        } else if (newWinningId === original.losing_team_id) {
             newWinningName = original.losing_team_name;
             newLosingName = original.winning_team_name;
-            newLosingId = original.winning_team_id;
+        } else {
+            // Fallback (shouldn't happen unless IDs changed drastically)
+            newWinningName = original.winning_team_name;
+            newLosingName = original.losing_team_name;
         }
 
         // We update mva/lvsc if provided, otherwise keep existing (or set to null? usually partial update logic, but here we can just overwrite)

--- a/apps/frontend/src/views/LeagueView.vue
+++ b/apps/frontend/src/views/LeagueView.vue
@@ -200,8 +200,8 @@ function padRoster(roster) {
 function openResultModal(series) {
     resultForm.value = {
         id: series.id,
-        team1Name: series.winner, // Originally winning_team_name before score
-        team2Name: series.loser,  // Originally losing_team_name before score
+        team1Name: series.winner_name || series.winner,
+        team2Name: series.loser_name || series.loser,
         team1Score: 0,
         team2Score: 0,
         team1Id: series.winning_team_id,


### PR DESCRIPTION
Fixes an outstanding issue with the "Enter Series Result" modal where the loser team name was rendering as an empty field. Updates backend to properly map `loser_team_name` into the payload and updates `POST /result` to use `team1_id`, `team1_score`, etc., determining the winner dynamically.

---
*PR created automatically by Jules for task [5377315582540838667](https://jules.google.com/task/5377315582540838667) started by @dc421*