### PR TITLE
Fix roster race condition and display issues on Dashboard load

### DIFF
--- a/apps/frontend/src/stores/auth.js
+++ b/apps/frontend/src/stores/auth.js
@@ -133,7 +133,7 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-async function fetchMyRoster(type = 'league') {
+async function fetchMyRoster(type = 'league', setActive = true) {
     if (!token.value) return;
     try {
       const response = await apiClient(`/api/my-roster?type=${type}`);
@@ -141,7 +141,9 @@ async function fetchMyRoster(type = 'league') {
       const data = await response.json();
       
       // Update the generic pointer
-      myRoster.value = data;
+      if (setActive) {
+          myRoster.value = data;
+      }
 
       // Update specific cache
       if (type === 'league') {
@@ -151,7 +153,9 @@ async function fetchMyRoster(type = 'league') {
       }
     } catch (error) {
       console.error('Failed to fetch roster:', error);
-      myRoster.value = null;
+      if (setActive) {
+          myRoster.value = null;
+      }
       if (type === 'league') myLeagueRoster.value = null;
       if (type === 'classic') myClassicRoster.value = null;
     }

--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -217,13 +217,12 @@ function closePlayerCard() {
 
 async function switchRosterTab(tab) {
     activeRosterTab.value = tab;
+
+    // Clear active cards immediately to prevent showing old cards while loading
+    authStore.activeRosterCards = [];
+
     // Reload roster for the new tab
     await authStore.fetchMyRoster(tab);
-
-    // If fetchMyRoster failed or returned null (no roster), clear the active cards display
-    if (!authStore.myRoster) {
-        authStore.activeRosterCards = [];
-    }
 
     // Update Series Type Logic based on tab
     if (tab === 'classic') {
@@ -232,10 +231,15 @@ async function switchRosterTab(tab) {
         seriesType.value = 'exhibition';
     }
 
+    // If fetchMyRoster failed or returned null (no roster), we're done
+    if (!authStore.myRoster) {
+        return;
+    }
+
     // Determine appropriate point set
     if (tab === 'classic') {
         const original = authStore.pointSets.find(ps => ps.name === 'Original Pts');
-        if (original && authStore.myRoster) {
+        if (original) {
             authStore.fetchRosterDetails(authStore.myRoster.roster_id, original.point_set_id);
         }
     } else {
@@ -244,7 +248,7 @@ async function switchRosterTab(tab) {
         const upcoming = authStore.pointSets.find(ps => ps.name === 'Upcoming Season');
         if (upcoming) targetSetId = upcoming.point_set_id;
 
-        if (authStore.myRoster && targetSetId) {
+        if (targetSetId) {
             authStore.fetchRosterDetails(authStore.myRoster.roster_id, targetSetId);
         }
     }
@@ -254,21 +258,13 @@ onMounted(async () => {
   // Ensure point sets are loaded to get the current season ID
   await authStore.fetchPointSets();
 
-  // Fetch BOTH rosters so availability logic works
-  await Promise.all([
-      authStore.fetchMyRoster('league'),
-      authStore.fetchMyRoster('classic')
-  ]);
+  // Fetch the active roster immediately to display it
+  await switchRosterTab(activeRosterTab.value);
 
-  // Determine correct point set for initial load (League default)
-  let targetSetId = authStore.selectedPointSetId;
-  const upcoming = authStore.pointSets.find(ps => ps.name === 'Upcoming Season');
-  if (upcoming) targetSetId = upcoming.point_set_id;
-
-  // Now fetch full roster details with points for the selected point set
-  if (authStore.myRoster && authStore.myRoster.roster_id && targetSetId) {
-      authStore.fetchRosterDetails(authStore.myRoster.roster_id, targetSetId);
-  }
+  // Fetch the other roster quietly in the background so availability logic works
+  // We pass false to setActive so it doesn't overwrite myRoster.value
+  const otherTab = activeRosterTab.value === 'league' ? 'classic' : 'league';
+  authStore.fetchMyRoster(otherTab, false);
 
   authStore.fetchMyGames();
   authStore.fetchOpenGames();


### PR DESCRIPTION
Resolves the race condition and long loading times on the Dashboard roster.

- Updated `fetchMyRoster` in `auth.js` to accept a `setActive` parameter that prevents overwriting the active pointer (`myRoster.value`) during background fetches.
- Updated `switchRosterTab` in `DashboardView.vue` to instantly clear the active roster array (`authStore.activeRosterCards = []`) preventing UI flashing with old point values, and cleanly skip fetching details if the roster doesn't exist.
- Updated `onMounted` hook in `DashboardView.vue` to sequentially resolve the tab loading by instantly loading the target active roster first, then passing `false` to silently fetch the inactive roster in the background for availability features, eliminating the `Promise.all` race condition.

---
*PR created automatically by Jules for task [2947760794165435917](https://jules.google.com/task/2947760794165435917) started by @dc421*