### PR TITLE
Fix Dashboard Empty Roster Blink

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -944,7 +944,7 @@ app.post('/api/login', async (req, res) => {
 // in server.js
 app.get('/api/my-roster', authenticateToken, async (req, res) => {
     const userId = req.user.userId;
-    const { type } = req.query;
+    const { type, point_set_id } = req.query;
     const rosterType = type || 'league'; // Default to 'league'
 
     try {
@@ -969,15 +969,29 @@ app.get('/api/my-roster', authenticateToken, async (req, res) => {
         }
         
         const roster = rosterResult.rows[0];
-        const cardsResult = await pool.query(
-            `SELECT cp.*, rc.is_starter, rc.assignment 
-             FROM cards_player cp 
-             JOIN roster_cards rc ON cp.card_id = rc.card_id 
-             WHERE rc.roster_id = $1`,
-            [roster.roster_id]
-        );
+        let cardsResult;
+
+        if (point_set_id) {
+            cardsResult = await pool.query(
+                `SELECT cp.*, rc.is_starter, rc.assignment, ppv.points
+                 FROM cards_player cp
+                 JOIN roster_cards rc ON cp.card_id = rc.card_id
+                 LEFT JOIN player_point_values ppv ON cp.card_id = ppv.card_id AND ppv.point_set_id = $2
+                 WHERE rc.roster_id = $1`,
+                [roster.roster_id, point_set_id]
+            );
+        } else {
+            cardsResult = await pool.query(
+                `SELECT cp.*, rc.is_starter, rc.assignment
+                 FROM cards_player cp
+                 JOIN roster_cards rc ON cp.card_id = rc.card_id
+                 WHERE rc.roster_id = $1`,
+                [roster.roster_id]
+            );
+        }
         
-        res.json({ ...roster, cards: cardsResult.rows });
+        const processedCards = processPlayers(cardsResult.rows);
+        res.json({ ...roster, cards: processedCards });
 
     } catch (error) {
         console.error('Error fetching user roster:', error);

--- a/apps/frontend/src/stores/auth.js
+++ b/apps/frontend/src/stores/auth.js
@@ -133,16 +133,28 @@ export const useAuthStore = defineStore('auth', () => {
     }
   }
 
-async function fetchMyRoster(type = 'league', setActive = true) {
+  const isFetchingRoster = ref(false);
+
+  async function fetchMyRoster(type = 'league', setActive = true, pointSetId = null) {
     if (!token.value) return;
+    if (setActive) isFetchingRoster.value = true;
     try {
-      const response = await apiClient(`/api/my-roster?type=${type}`);
+      let url = `/api/my-roster?type=${type}`;
+      if (pointSetId) {
+          url += `&point_set_id=${pointSetId}`;
+      }
+      const response = await apiClient(url);
       if (!response.ok) throw new Error('Failed to fetch roster');
       const data = await response.json();
       
       // Update the generic pointer
       if (setActive) {
           myRoster.value = data;
+          if (data && data.cards) {
+              activeRosterCards.value = data.cards;
+          } else {
+              activeRosterCards.value = [];
+          }
       }
 
       // Update specific cache
@@ -155,9 +167,12 @@ async function fetchMyRoster(type = 'league', setActive = true) {
       console.error('Failed to fetch roster:', error);
       if (setActive) {
           myRoster.value = null;
+          activeRosterCards.value = [];
       }
       if (type === 'league') myLeagueRoster.value = null;
       if (type === 'classic') myClassicRoster.value = null;
+    } finally {
+      if (setActive) isFetchingRoster.value = false;
     }
   }
 
@@ -350,7 +365,7 @@ async function submitLineup(gameId, lineupData) {
 
   return { 
     token, user, allPlayers, myGames, openGames, activeRosterCards, API_URL, router,
-    pointSets, selectedPointSetId,
+    pointSets, selectedPointSetId, isFetchingRoster,
     isAuthenticated, login, register, logout, myRoster, myLeagueRoster, myClassicRoster, fetchMyRoster, saveRoster,
     fetchAllPlayers, fetchMyGames, fetchOpenGames, joinGame,fetchAvailableTeams,
     submitLineup, fetchRosterDetails, createGame, fetchMyParticipantInfo,availableTeams,

--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -218,12 +218,6 @@ function closePlayerCard() {
 async function switchRosterTab(tab) {
     activeRosterTab.value = tab;
 
-    // Clear active cards immediately to prevent showing old cards while loading
-    authStore.activeRosterCards = [];
-
-    // Reload roster for the new tab
-    await authStore.fetchMyRoster(tab);
-
     // Update Series Type Logic based on tab
     if (tab === 'classic') {
         seriesType.value = 'classic';
@@ -231,27 +225,21 @@ async function switchRosterTab(tab) {
         seriesType.value = 'exhibition';
     }
 
-    // If fetchMyRoster failed or returned null (no roster), we're done
-    if (!authStore.myRoster) {
-        return;
-    }
-
-    // Determine appropriate point set
+    // Determine appropriate point set BEFORE fetching
+    let targetSetId = null;
     if (tab === 'classic') {
         const original = authStore.pointSets.find(ps => ps.name === 'Original Pts');
-        if (original) {
-            authStore.fetchRosterDetails(authStore.myRoster.roster_id, original.point_set_id);
-        }
+        if (original) targetSetId = original.point_set_id;
     } else {
         // League: Prefer "Upcoming Season"
-        let targetSetId = authStore.selectedPointSetId;
+        targetSetId = authStore.selectedPointSetId;
         const upcoming = authStore.pointSets.find(ps => ps.name === 'Upcoming Season');
         if (upcoming) targetSetId = upcoming.point_set_id;
-
-        if (targetSetId) {
-            authStore.fetchRosterDetails(authStore.myRoster.roster_id, targetSetId);
-        }
     }
+
+    // Reload roster for the new tab, passing targetSetId so it fetches cards immediately
+    // We do NOT clear authStore.activeRosterCards here to prevent "empty roster" message flickering
+    await authStore.fetchMyRoster(tab, true, targetSetId);
 }
 
 onMounted(async () => {
@@ -349,7 +337,10 @@ onUnmounted(() => {
           <!-- Empty Check: Only if NO players at all (length 0 before padding, but we pad now).
                So if only placeholders exist, it's empty.
                We check if the first element is empty. -->
-          <div v-if="processedRoster.length === 0 || processedRoster[0].isEmpty" class="empty-roster-message">
+          <div v-if="authStore.isFetchingRoster" class="empty-roster-message">
+              <p>Loading {{ activeRosterTab === 'classic' ? 'Classic' : 'League' }} roster...</p>
+          </div>
+          <div v-else-if="processedRoster.length === 0 || processedRoster[0].isEmpty" class="empty-roster-message">
               <p>Your {{ activeRosterTab === 'classic' ? 'Classic' : 'League' }} roster is empty.</p>
               <button @click="goToRosterBuilder" class="create-roster-btn">Create Roster</button>
           </div>


### PR DESCRIPTION
Fixes the issue where the "Your League roster is empty" message briefly flashes on page load. By optimizing the API to return the roster and its cards in a single request, and by utilizing a boolean loading state, the UI now waits gracefully for data rather than defaulting to empty prematurely.

---
*PR created automatically by Jules for task [16538318958036312627](https://jules.google.com/task/16538318958036312627) started by @dc421*