### PR TITLE
Fix: prevent empty game lists from flickering on Dashboard load

### DIFF
--- a/apps/frontend/src/stores/auth.js
+++ b/apps/frontend/src/stores/auth.js
@@ -15,6 +15,8 @@ export const useAuthStore = defineStore('auth', () => {
   const myGames = ref([]);
   const openGames = ref([]);
   const activeRosterCards = ref([]);
+  const isFetchingGames = ref(false);
+  const isFetchingOpenGames = ref(false);
   // API_URL is handled inside apiClient, but we expose it if needed by components
   // (though they should prefer using apiClient or store actions)
   const API_URL = import.meta.env.VITE_API_URL || '';
@@ -234,23 +236,29 @@ async function fetchAvailableTeams() {
   
   async function fetchMyGames() {
     if (!token.value) return;
+    isFetchingGames.value = true;
     try {
         const response = await apiClient(`/api/games`);
         if (!response.ok) throw new Error('Failed to fetch games');
         myGames.value = await response.json();
     } catch (error) {
         console.error(error);
+    } finally {
+        isFetchingGames.value = false;
     }
   }
 
   async function fetchOpenGames() {
     if (!token.value) return;
+    isFetchingOpenGames.value = true;
     try {
         const response = await apiClient(`/api/games/open`);
         if (!response.ok) throw new Error('Failed to fetch open games');
         openGames.value = await response.json();
     } catch (error) {
         console.error(error);
+    } finally {
+        isFetchingOpenGames.value = false;
     }
   }
 
@@ -365,7 +373,7 @@ async function submitLineup(gameId, lineupData) {
 
   return { 
     token, user, allPlayers, myGames, openGames, activeRosterCards, API_URL, router,
-    pointSets, selectedPointSetId, isFetchingRoster,
+    pointSets, selectedPointSetId, isFetchingRoster, isFetchingGames, isFetchingOpenGames,
     isAuthenticated, login, register, logout, myRoster, myLeagueRoster, myClassicRoster, fetchMyRoster, saveRoster,
     fetchAllPlayers, fetchMyGames, fetchOpenGames, joinGame,fetchAvailableTeams,
     submitLineup, fetchRosterDetails, createGame, fetchMyParticipantInfo,availableTeams,

--- a/apps/frontend/src/views/DashboardView.vue
+++ b/apps/frontend/src/views/DashboardView.vue
@@ -379,7 +379,8 @@ onUnmounted(() => {
                 <h2>Active Games</h2>
             </div>
             
-            <ul v-if="activeGames.length > 0" class="game-list">
+            <p v-if="authStore.isFetchingGames">Loading active games...</p>
+            <ul v-else-if="activeGames.length > 0" class="game-list">
                 <li v-for="game in activeGames" :key="game.game_id" class="game-list-item">
                     <div v-if="isDeleteMode" class="checkbox-wrapper">
                         <input type="checkbox" :value="game.game_id" v-model="selectedGamesToDelete" />
@@ -420,7 +421,8 @@ onUnmounted(() => {
                 </template>
             </div>
             <h3 class="join-header">Open Games to Join</h3>
-            <ul v-if="gamesToJoin.length > 0" class="game-list">
+            <p v-if="authStore.isFetchingOpenGames">Loading open games...</p>
+            <ul v-else-if="gamesToJoin.length > 0" class="game-list">
               <li v-for="game in gamesToJoin" :key="game.game_id">
                 <span>{{ getGameTypeName(game.series_type) }} vs. {{ game.full_display_name }}</span>
                 <button @click="handleJoinGame(game)" :disabled="(game.series_type === 'classic' ? !authStore.myClassicRoster : !authStore.myLeagueRoster) || (game.series_type !== 'classic' && authStore.isDraftActive)">
@@ -435,7 +437,8 @@ onUnmounted(() => {
       <!-- COLUMN 3: Completed Games -->
        <div class="panel">
         <h2>Completed Games</h2>
-        <ul v-if="completedGames.length > 0" class="game-list">
+        <p v-if="authStore.isFetchingGames">Loading completed games...</p>
+        <ul v-else-if="completedGames.length > 0" class="game-list">
           <li v-for="game in completedGames" :key="game.game_id">
             <RouterLink :to="`/game/${game.game_id}`">
               <GameScorecard :game="game" />

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Adds specific fetch tracking states (`isFetchingGames` and `isFetchingOpenGames`) to `authStore` to prevent empty state UI flicker. Updates `DashboardView.vue` to show a temporary loading state for Active Games, Open Games to Join, and Completed Games.

---
*PR created automatically by Jules for task [11681747031940383517](https://jules.google.com/task/11681747031940383517) started by @dc421*