### PR TITLE
Restrict transient substitutions from swapping lineup slots

### DIFF
--- a/apps/backend/server.js
+++ b/apps/backend/server.js
@@ -28,6 +28,9 @@ function commitTransientPlayerIds(state) {
         if (state[teamKey].transient_subbed_in_player_ids) {
             state[teamKey].transient_subbed_in_player_ids = [];
         }
+        if (state[teamKey].transient_lineup_slots) {
+            state[teamKey].transient_lineup_slots = {};
+        }
     }
 }
 
@@ -1528,7 +1531,20 @@ const stateResult = await client.query('SELECT * FROM game_states WHERE game_id 
 
     // If the player is being subbed back in and they are in the transient list, we remove them from the transient list
     if (newState[teamKey].transient_used_player_ids && newState[teamKey].transient_used_player_ids.includes(playerInIdInt)) {
+        // Enforce that transiently removed players can only be subbed back into their original slot
+        const expectedSlot = newState[teamKey].transient_lineup_slots?.[playerInIdInt];
+        const currentSlotKey = lineupIndex >= 0 ? lineupIndex.toString() : 'pitcher';
+
+        if (expectedSlot !== undefined && expectedSlot !== currentSlotKey) {
+            let slotName = expectedSlot === 'pitcher' ? "the pitcher's spot" : `lineup spot ${parseInt(expectedSlot) + 1}`;
+            return res.status(400).json({ message: `This player was removed from ${slotName} and can only be placed back into that spot.` });
+        }
+
         newState[teamKey].transient_used_player_ids = newState[teamKey].transient_used_player_ids.filter(id => id !== playerInIdInt);
+
+        if (newState[teamKey].transient_lineup_slots) {
+            delete newState[teamKey].transient_lineup_slots[playerInIdInt];
+        }
     } else {
         if (!newState[teamKey].transient_subbed_in_player_ids) {
             newState[teamKey].transient_subbed_in_player_ids = [];
@@ -1840,6 +1856,13 @@ const stateResult = await client.query('SELECT * FROM game_states WHERE game_id 
             }
             if (!newState[teamKey].transient_used_player_ids.includes(playerOutIdInt) && !(newState[teamKey].used_player_ids && newState[teamKey].used_player_ids.includes(playerOutIdInt))) {
                 newState[teamKey].transient_used_player_ids.push(playerOutIdInt);
+
+                // Record the slot they were removed from
+                if (!newState[teamKey].transient_lineup_slots) {
+                    newState[teamKey].transient_lineup_slots = {};
+                }
+                const removedSlotKey = lineupIndex >= 0 ? lineupIndex.toString() : 'pitcher';
+                newState[teamKey].transient_lineup_slots[playerOutIdInt] = removedSlotKey;
             }
         }
     }

--- a/apps/frontend/src/views/GameView.vue
+++ b/apps/frontend/src/views/GameView.vue
@@ -700,6 +700,27 @@ const usedPlayerIds = computed(() => {
     return new Set(teamUsed);
 });
 
+const myTransientLineupSlots = computed(() => {
+    if (!gameStore.gameState || !leftPanelData.value?.teamKey) return {};
+    const teamKey = leftPanelData.value.teamKey;
+    return gameStore.gameState[teamKey + 'Team']?.transient_lineup_slots || {};
+});
+
+const isPlayerValidSubTarget = (player) => {
+    if (!player) return false;
+    if (usedPlayerIds.value.has(player.card_id)) return false;
+
+    // Check if player is transiently subbed out and restricted to a specific slot
+    const transientSlot = myTransientLineupSlots.value[player.card_id];
+    if (transientSlot !== undefined && playerToSubOut.value) {
+        const currentSlotKey = playerToSubOut.value.source === 'lineup' ? playerToSubOut.value.index.toString() : 'pitcher';
+        if (transientSlot !== currentSlotKey) {
+            return false;
+        }
+    }
+    return true;
+};
+
 const opponentUsedPlayerIds = computed(() => {
     if (!gameStore.gameState || !rightPanelData.value?.teamKey) return new Set();
     const teamKey = rightPanelData.value.teamKey;
@@ -2518,10 +2539,10 @@ function handleVisibilityChange() {
           <div v-if="leftPanelData.bullpen.length > 0">
               <hr /><strong :style="{ color: leftPanelData.colors.primary }">Bullpen:</strong>
               <ul>
-                  <li v-for="p in leftPanelData.bullpen" :key="p.card_id" class="lineup-item" :class="{'is-sub-in-candidate': isSubModeActive && playerToSubOut && !usedPlayerIds.has(p.card_id)}">
+                  <li v-for="p in leftPanelData.bullpen" :key="p.card_id" class="lineup-item" :class="{'is-sub-in-candidate': isSubModeActive && playerToSubOut && isPlayerValidSubTarget(p)}">
                       <span @click.stop="handleSubstitution(p)"
                             class="sub-icon"
-                            :class="{ 'visible': isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && !usedPlayerIds.has(p.card_id) && isStartingPitcherEligible }">
+                            :class="{ 'visible': isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && isPlayerValidSubTarget(p) && isStartingPitcherEligible }">
                           ⇄
                       </span>
                       <span @click="selectedCard = p" :class="{'is-used': usedPlayerIds.has(p.card_id), 'is-tired': p.fatigueStatus === 'tired' && !usedPlayerIds.has(p.card_id)}">{{ p.displayName }} ({{p.ip}} IP)</span>
@@ -2535,10 +2556,10 @@ function handleVisibilityChange() {
           <div v-if="leftPanelData.bench.length > 0">
               <hr /><strong :style="{ color: leftPanelData.colors.primary }">Bench:</strong>
               <ul>
-                  <li v-for="(p, index) in leftPanelData.bench" :key="index" class="lineup-item" :class="{'is-sub-in-candidate': isSubModeActive && playerToSubOut && !usedPlayerIds.has(p.card_id)}">
+                  <li v-for="(p, index) in leftPanelData.bench" :key="index" class="lineup-item" :class="{'is-sub-in-candidate': isSubModeActive && playerToSubOut && isPlayerValidSubTarget(p)}">
                       <span @click.stop="handleSubstitution(p)"
                             class="sub-icon"
-                            :class="{ 'visible': isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && !usedPlayerIds.has(p.card_id) && (amIDisplayOffensivePlayer || gameStore.gameState.inning >= 7 || p.assignment !== 'BENCH') }">
+                            :class="{ 'visible': isSubModeActive && playerToSubOut && leftPanelData.isMyTeam && isPlayerValidSubTarget(p) && (amIDisplayOffensivePlayer || gameStore.gameState.inning >= 7 || p.assignment !== 'BENCH') }">
                           ⇄
                       </span>
                       <span @click="selectedCard = p" :class="{'is-used': usedPlayerIds.has(p.card_id)}">{{ p.displayName }} ({{p.displayPosition}})</span>


### PR DESCRIPTION
This change fixes an issue where players could sub someone out of the lineup and then transiently place them back into a completely different lineup slot before committing the action. By recording the original slot in `transient_lineup_slots`, both the frontend UI and backend validation now strictly enforce that transient players can only be swapped back into their exact vacated spot.

---
*PR created automatically by Jules for task [1527130700616145861](https://jules.google.com/task/1527130700616145861) started by @dc421*